### PR TITLE
chore: add missing .PHONY annotation to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build debug build-musl run install
+
 build:
 	rm -rf bin
 	go build -o bin/vinit ./cmd/versainit


### PR DESCRIPTION
## Summary
- Added `.PHONY` declaration for all Makefile targets (`build`, `debug`, `build-musl`, `run`, `install`) to prevent conflicts with files of the same name

## Test plan
- [ ] Verify `make` targets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)