### PR TITLE
feat(system): add dev system cleanup command to reclaim disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `dev system cleanup` command -- reclaims disk space by clearing Go, Node, Python, Gradle, JetBrains, Terra, and SDKMAN caches, pruning obsolete Claude Code and cursor-agent binary versions, and wiping transient Claude Code state, while preserving credentials, shell history, and installed SDK runtimes
+- added `RemoveAll` to the `FileSystem` interface with a `DefaultFileSystem` implementation and matching support in `FileSystemStub`
+
 ## [0.6.0] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ DevForge is a developer workspace toolkit that manages Git repositories across m
 - **Fork Syncing**: detects forked repos via provider API, syncs with upstream parent, and handles conflicts by creating reference branches
 - **Branch Pruning**: deletes local branches merged into the default branch across all repos
 - **Docker Management**: lists container IPs and resets the Docker environment (stop, prune)
+- **System Cleanup**: reclaims disk space by clearing caches across Go, Node, Python, Gradle, JetBrains, Terra, and SDKMAN, pruning obsolete CLI-agent binary versions, and wiping transient state -- credentials, SDKs, and shell history are preserved
 - **Multi-Provider Support**: automatic provider detection from directory path with per-provider auth tokens
 
 ## Installation

--- a/cmd/devforge/main.go
+++ b/cmd/devforge/main.go
@@ -86,6 +86,7 @@ func main() {
 	}
 	systemCmd.AddCommand(newSystemTop5SizeCmd())
 	systemCmd.AddCommand(newSystemClearHistoryCmd())
+	systemCmd.AddCommand(newSystemCleanupCmd())
 	if system.IsLinux() {
 		systemCmd.AddCommand(newSystemClearLogsCmd())
 	}
@@ -505,6 +506,31 @@ func newSystemClearHistoryCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return system.RunClearHistory(&system.DefaultFileSystem{}, dryRun, os.Stderr)
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be removed without removing")
+
+	return cmd
+}
+
+func newSystemCleanupCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Reclaim disk space by clearing caches and obsolete tool downloads",
+		Long: `Cleans up caches, transient downloads, and obsolete tool-version
+artifacts under $HOME. Credentials, configs, shell history, and installed
+SDK runtimes are never touched.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return system.RunCleanup(system.CleanupConfig{
+				Runner: &system.DefaultRunner{},
+				FS:     &system.DefaultFileSystem{},
+				DryRun: dryRun,
+				Output: os.Stderr,
+			})
 		},
 	}
 

--- a/internal/system/cleanup.go
+++ b/internal/system/cleanup.go
@@ -1,8 +1,10 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -122,12 +124,12 @@ func cleanupGo(cfg CleanupConfig, homeDir string) int64 {
 	if cfg.hasBinary("go") {
 		goCachePath := filepath.Join(homeDir, ".cache/go-build")
 		goModCachePath := filepath.Join(homeDir, "go/pkg/mod")
-		before := pathSize(cfg, goCachePath) + pathSize(cfg, goModCachePath)
+		before := safeSize(cfg, goCachePath) + safeSize(cfg, goModCachePath)
 		runTool(cfg, "go clean -cache", "go", "clean", "-cache")
 		runTool(cfg, "go clean -modcache", "go", "clean", "-modcache")
 		runTool(cfg, "go clean -testcache", "go", "clean", "-testcache")
 		if !cfg.DryRun {
-			reclaimed += before - pathSize(cfg, goCachePath) - pathSize(cfg, goModCachePath)
+			reclaimed += before - safeSize(cfg, goCachePath) - safeSize(cfg, goModCachePath)
 		} else {
 			reclaimed += before
 		}
@@ -146,12 +148,12 @@ func cleanupGo(cfg CleanupConfig, homeDir string) int64 {
 func cleanupTerra(cfg CleanupConfig, homeDir string) int64 {
 	if cfg.hasBinary("terra") {
 		terraCachePath := filepath.Join(homeDir, ".cache/terra")
-		before := pathSize(cfg, terraCachePath)
+		before := safeSize(cfg, terraCachePath)
 		runTool(cfg, "terra clear --global", "terra", "clear", "--global")
 		if cfg.DryRun {
 			return before
 		}
-		return before - pathSize(cfg, terraCachePath)
+		return before - safeSize(cfg, terraCachePath)
 	}
 	return removePath(cfg, filepath.Join(homeDir, ".cache/terra"), ".cache/terra")
 }
@@ -183,12 +185,12 @@ func cleanupNode(cfg CleanupConfig, homeDir string) int64 {
 	var reclaimed int64
 	if cfg.hasBinary("npm") {
 		cachePath := filepath.Join(homeDir, ".npm/_cacache")
-		before := pathSize(cfg, cachePath)
+		before := safeSize(cfg, cachePath)
 		runTool(cfg, "npm cache clean --force", "npm", "cache", "clean", "--force")
 		if cfg.DryRun {
 			reclaimed += before
 		} else {
-			reclaimed += before - pathSize(cfg, cachePath)
+			reclaimed += before - safeSize(cfg, cachePath)
 		}
 	} else {
 		reclaimed += removePath(cfg, filepath.Join(homeDir, ".npm/_cacache"), ".npm/_cacache")
@@ -206,12 +208,12 @@ func cleanupPython(cfg CleanupConfig, homeDir string) int64 {
 	var reclaimed int64
 	if cfg.hasBinary("pip") {
 		pipCachePath := filepath.Join(homeDir, ".cache/pip")
-		before := pathSize(cfg, pipCachePath)
+		before := safeSize(cfg, pipCachePath)
 		runTool(cfg, "pip cache purge", "pip", "cache", "purge")
 		if cfg.DryRun {
 			reclaimed += before
 		} else {
-			reclaimed += before - pathSize(cfg, pipCachePath)
+			reclaimed += before - safeSize(cfg, pipCachePath)
 		}
 	} else {
 		reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/pip"), ".cache/pip")
@@ -286,25 +288,55 @@ func cleanupMiscStale(cfg CleanupConfig, homeDir string) int64 {
 
 // -- Helpers -----------------------------------------------------------------
 
-// removePath removes a file or directory recursively. In dry-run mode it
-// only reports what would be removed. Returns the number of bytes that were
-// (or would have been) freed.
-func removePath(cfg CleanupConfig, path, label string) int64 {
-	size := pathSize(cfg, path)
-	if size == 0 {
-		logf(cfg.Output, "[skip] %s (absent or empty)", label)
+// pathExists reports whether the path is present on the filesystem. Uses
+// Lstat so broken symlinks (which still occupy space) are treated as present.
+func pathExists(cfg CleanupConfig, path string) bool {
+	_, err := cfg.FS.Lstat(path)
+	return err == nil
+}
+
+// safeSize returns the size of a path if it exists, else 0. Used by category
+// functions that compute "before/after" totals around tool-native cleaners,
+// where some target paths may legitimately be absent.
+func safeSize(cfg CleanupConfig, path string) int64 {
+	if !pathExists(cfg, path) {
 		return 0
 	}
+	return pathSize(cfg, path)
+}
+
+// formatSizeSuffix renders a parenthesised size suffix for log lines, or an
+// empty string when the size is unknown (0).
+func formatSizeSuffix(size int64, verb string) string {
+	if size <= 0 {
+		return ""
+	}
+	if verb == "" {
+		return " (" + formatBytes(size) + ")"
+	}
+	return " (" + formatBytes(size) + " " + verb + ")"
+}
+
+// removePath removes a file or directory recursively. Existence is
+// determined by Lstat (not by size), so legitimately empty files such as
+// `.wget-hsts` are still removed. Size reporting is best-effort: when `du`
+// cannot determine the size the path is still removed, the per-entry total
+// contributes 0 to the summary, and the log line omits the size suffix.
+func removePath(cfg CleanupConfig, path, label string) int64 {
+	if !pathExists(cfg, path) {
+		logf(cfg.Output, "[skip] %s (absent)", label)
+		return 0
+	}
+	size := pathSize(cfg, path)
+	logf(cfg.Output, "[plan] %s%s", label, formatSizeSuffix(size, ""))
 	if cfg.DryRun {
-		logf(cfg.Output, "[plan] %s (%s)", label, formatBytes(size))
 		return size
 	}
-	logf(cfg.Output, "[plan] %s (%s)", label, formatBytes(size))
 	if err := cfg.FS.RemoveAll(path); err != nil {
 		logf(cfg.Output, "warning: %v", err)
 		return 0
 	}
-	logf(cfg.Output, "[done] %s (%s reclaimed)", label, formatBytes(size))
+	logf(cfg.Output, "[done] %s%s", label, formatSizeSuffix(size, "reclaimed"))
 	return size
 }
 
@@ -332,7 +364,13 @@ func removeGlob(cfg CleanupConfig, pattern, label string) int64 {
 func keepLatestVersion(cfg CleanupConfig, dir, label string) int64 {
 	entries, err := cfg.FS.ReadDir(dir)
 	if err != nil {
-		logf(cfg.Output, "[skip] %s (absent)", label)
+		if errors.Is(err, os.ErrNotExist) {
+			logf(cfg.Output, "[skip] %s (absent)", label)
+			return 0
+		}
+		// Permission errors, transient IO failures, etc. deserve visibility
+		// rather than being silently reported as "(absent)".
+		logf(cfg.Output, "warning: reading %s: %v", label, err)
 		return 0
 	}
 	names := make([]string, 0, len(entries))
@@ -380,11 +418,15 @@ func runTool(cfg CleanupConfig, label, bin string, args ...string) {
 	logf(cfg.Output, "[done] %s", label)
 }
 
-// pathSize returns the total size of a path in bytes via `du -sb`. Returns 0
-// if the path does not exist or du fails.
+// pathSize returns the total size of a path in bytes via `du -sb`. Callers
+// must have verified that the path exists (e.g. via [pathExists]) before
+// calling -- any error from `du` is therefore treated as a tool-level
+// failure (missing binary, permission denied, etc.), logged as a warning,
+// and reported as size 0 so the caller can still proceed with removal.
 func pathSize(cfg CleanupConfig, path string) int64 {
 	raw, err := cfg.Runner.Output("du", "-sb", path)
 	if err != nil {
+		logf(cfg.Output, "warning: du %s: %v", path, err)
 		return 0
 	}
 	parts := strings.SplitN(strings.TrimSpace(raw), "\t", duFieldCount)

--- a/internal/system/cleanup.go
+++ b/internal/system/cleanup.go
@@ -1,0 +1,441 @@
+package system
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// CleanupConfig bundles the dependencies needed by [RunCleanup].
+type CleanupConfig struct {
+	Runner Runner
+	FS     FileSystem
+	DryRun bool
+	Output io.Writer
+	// LookPath reports whether a binary is available on PATH. When nil,
+	// [exec.LookPath] is used. Overriding this keeps unit tests free of
+	// host-specific binary assumptions.
+	LookPath func(bin string) bool
+}
+
+func (cfg CleanupConfig) hasBinary(bin string) bool {
+	if cfg.LookPath != nil {
+		return cfg.LookPath(bin)
+	}
+	_, err := exec.LookPath(bin)
+	return err == nil
+}
+
+// RunCleanup reclaims disk space in $HOME by clearing caches, transient
+// downloads, and obsolete tool-version artifacts. Credentials, configs,
+// shell history, and installed SDK runtimes are never touched.
+//
+// Categories run sequentially and a failure in one does not abort the
+// others. The function returns an error only when $HOME cannot be resolved.
+func RunCleanup(cfg CleanupConfig) error {
+	homeDir, err := cfg.FS.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", err)
+	}
+
+	if cfg.DryRun {
+		logf(cfg.Output, "(dry-run mode)")
+	}
+
+	type categoryFn func(cfg CleanupConfig, homeDir string) int64
+
+	categories := []struct {
+		name string
+		fn   categoryFn
+	}{
+		{"JetBrains caches", cleanupJetBrains},
+		{"Go caches", cleanupGo},
+		{"Terra/Terraform caches", cleanupTerra},
+		{"Gradle", cleanupGradle},
+		{"SDKMAN", cleanupSDKMAN},
+		{"Node/JS caches", cleanupNode},
+		{"Python caches", cleanupPython},
+		{"CLI agent old versions", cleanupAgentVersions},
+		{"Miscellaneous caches", cleanupMisc},
+		{"Claude Code transient state", cleanupClaudeState},
+		{"Misc stale files", cleanupMiscStale},
+	}
+
+	var total int64
+	for _, c := range categories {
+		logf(cfg.Output, "==> %s", c.name)
+		total += c.fn(cfg, homeDir)
+	}
+
+	logf(cfg.Output, "==> Summary")
+	if cfg.DryRun {
+		logf(cfg.Output, "dry-run total (would reclaim): %s", formatBytes(total))
+	} else {
+		logf(cfg.Output, "reclaimed: %s", formatBytes(total))
+	}
+	logf(cfg.Output, "preserved: credentials, shell history, installed SDKs, user work")
+	return nil
+}
+
+// -- Category: JetBrains ------------------------------------------------------
+
+func cleanupJetBrains(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+
+	// Remote IDE backend distributions — re-downloaded by Gateway on next connect.
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/JetBrains/RemoteDev/dist"),
+		".cache/JetBrains/RemoteDev/dist")
+
+	// Per-product cache/log/tmp subfolders. Product dirs themselves remain so
+	// the IDE can write fresh indexes on launch.
+	productsDir := filepath.Join(homeDir, ".cache/JetBrains")
+	entries, err := cfg.FS.ReadDir(productsDir)
+	if err != nil {
+		return reclaimed
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "RemoteDev" || strings.HasPrefix(name, "RemoteDev-") {
+			continue // already handled above
+		}
+		base := filepath.Join(productsDir, name)
+		reclaimed += removePath(cfg, filepath.Join(base, "caches"), ".cache/JetBrains/"+name+"/caches")
+		reclaimed += removePath(cfg, filepath.Join(base, "log"), ".cache/JetBrains/"+name+"/log")
+		reclaimed += removePath(cfg, filepath.Join(base, "tmp"), ".cache/JetBrains/"+name+"/tmp")
+	}
+	return reclaimed
+}
+
+// -- Category: Go -------------------------------------------------------------
+
+func cleanupGo(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+
+	// Tool-native cleaners handle read-only permissions in the module cache.
+	if cfg.hasBinary("go") {
+		goCachePath := filepath.Join(homeDir, ".cache/go-build")
+		goModCachePath := filepath.Join(homeDir, "go/pkg/mod")
+		before := pathSize(cfg, goCachePath) + pathSize(cfg, goModCachePath)
+		runTool(cfg, "go clean -cache", "go", "clean", "-cache")
+		runTool(cfg, "go clean -modcache", "go", "clean", "-modcache")
+		runTool(cfg, "go clean -testcache", "go", "clean", "-testcache")
+		if !cfg.DryRun {
+			reclaimed += before - pathSize(cfg, goCachePath) - pathSize(cfg, goModCachePath)
+		} else {
+			reclaimed += before
+		}
+	} else {
+		// Fallback: direct removal if `go` is not on PATH.
+		reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/go-build"), ".cache/go-build")
+		reclaimed += removePath(cfg, filepath.Join(homeDir, "go/pkg/mod"), "go/pkg/mod")
+	}
+
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/golangci-lint"), ".cache/golangci-lint")
+	return reclaimed
+}
+
+// -- Category: Terra ----------------------------------------------------------
+
+func cleanupTerra(cfg CleanupConfig, homeDir string) int64 {
+	if cfg.hasBinary("terra") {
+		terraCachePath := filepath.Join(homeDir, ".cache/terra")
+		before := pathSize(cfg, terraCachePath)
+		runTool(cfg, "terra clear --global", "terra", "clear", "--global")
+		if cfg.DryRun {
+			return before
+		}
+		return before - pathSize(cfg, terraCachePath)
+	}
+	return removePath(cfg, filepath.Join(homeDir, ".cache/terra"), ".cache/terra")
+}
+
+// -- Category: Gradle ---------------------------------------------------------
+
+func cleanupGradle(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	runTool(cfg, "gradle --stop", "gradle", "--stop")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".gradle/caches"), ".gradle/caches")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".gradle/daemon"), ".gradle/daemon")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".gradle/wrapper"), ".gradle/wrapper")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".gradle/native"), ".gradle/native")
+	return reclaimed
+}
+
+// -- Category: SDKMAN ---------------------------------------------------------
+
+func cleanupSDKMAN(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".sdkman/tmp"), ".sdkman/tmp")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".sdkman/archives"), ".sdkman/archives")
+	return reclaimed
+}
+
+// -- Category: Node / JS ------------------------------------------------------
+
+func cleanupNode(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	if cfg.hasBinary("npm") {
+		cachePath := filepath.Join(homeDir, ".npm/_cacache")
+		before := pathSize(cfg, cachePath)
+		runTool(cfg, "npm cache clean --force", "npm", "cache", "clean", "--force")
+		if cfg.DryRun {
+			reclaimed += before
+		} else {
+			reclaimed += before - pathSize(cfg, cachePath)
+		}
+	} else {
+		reclaimed += removePath(cfg, filepath.Join(homeDir, ".npm/_cacache"), ".npm/_cacache")
+	}
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".npm/_npx"), ".npm/_npx")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".npm/_logs"), ".npm/_logs")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".yarn/berry/cache"), ".yarn/berry/cache")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/node-gyp"), ".cache/node-gyp")
+	return reclaimed
+}
+
+// -- Category: Python ---------------------------------------------------------
+
+func cleanupPython(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	if cfg.hasBinary("pip") {
+		pipCachePath := filepath.Join(homeDir, ".cache/pip")
+		before := pathSize(cfg, pipCachePath)
+		runTool(cfg, "pip cache purge", "pip", "cache", "purge")
+		if cfg.DryRun {
+			reclaimed += before
+		} else {
+			reclaimed += before - pathSize(cfg, pipCachePath)
+		}
+	} else {
+		reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/pip"), ".cache/pip")
+	}
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/pdm"), ".cache/pdm")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/pysigma"), ".cache/pysigma")
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".cache/black"), ".cache/black")
+	return reclaimed
+}
+
+// -- Category: CLI agent old versions ----------------------------------------
+
+func cleanupAgentVersions(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	reclaimed += keepLatestVersion(cfg, filepath.Join(homeDir, ".local/share/claude/versions"),
+		"claude agent versions")
+	reclaimed += keepLatestVersion(cfg, filepath.Join(homeDir, ".local/share/cursor-agent/versions"),
+		"cursor-agent versions")
+	return reclaimed
+}
+
+// -- Category: Misc small caches ---------------------------------------------
+
+func cleanupMisc(cfg CleanupConfig, homeDir string) int64 {
+	miscPaths := []struct{ rel, label string }{
+		{".cache/trivy", ".cache/trivy"},
+		{".cache/helm", ".cache/helm"},
+		{".cache/github-copilot", ".cache/github-copilot"},
+		{".cache/claude-cli-nodejs", ".cache/claude-cli-nodejs"},
+		{".cache/gh", ".cache/gh"},
+		{".cache/fontconfig", ".cache/fontconfig"},
+		{".cache/JNA", ".cache/JNA"},
+		{".cache/zinit", ".cache/zinit"},
+	}
+	var reclaimed int64
+	for _, p := range miscPaths {
+		reclaimed += removePath(cfg, filepath.Join(homeDir, p.rel), p.label)
+	}
+	return reclaimed
+}
+
+// -- Category: Claude Code transient state -----------------------------------
+
+func cleanupClaudeState(cfg CleanupConfig, homeDir string) int64 {
+	// Preserved: settings*.json, rules/, agents/, commands/, memory/,
+	// projects/ (conversation history), plans/, tasks/, todos/, plugins/,
+	// backups/, history.jsonl.
+	transient := []struct{ rel, label string }{
+		{".claude/file-history", ".claude/file-history"},
+		{".claude/shell-snapshots", ".claude/shell-snapshots"},
+		{".claude/paste-cache", ".claude/paste-cache"},
+		{".claude/session-env", ".claude/session-env"},
+		{".claude/telemetry", ".claude/telemetry"},
+		{".claude/debug", ".claude/debug"},
+		{".claude/cache", ".claude/cache"},
+	}
+	var reclaimed int64
+	for _, p := range transient {
+		reclaimed += removePath(cfg, filepath.Join(homeDir, p.rel), p.label)
+	}
+	return reclaimed
+}
+
+// -- Category: Misc stale files ----------------------------------------------
+
+func cleanupMiscStale(cfg CleanupConfig, homeDir string) int64 {
+	var reclaimed int64
+	reclaimed += removePath(cfg, filepath.Join(homeDir, ".wget-hsts"), ".wget-hsts")
+	reclaimed += removeGlob(cfg, filepath.Join(homeDir, ".zcompdump*"), ".zcompdump*")
+	return reclaimed
+}
+
+// -- Helpers -----------------------------------------------------------------
+
+// removePath removes a file or directory recursively. In dry-run mode it
+// only reports what would be removed. Returns the number of bytes that were
+// (or would have been) freed.
+func removePath(cfg CleanupConfig, path, label string) int64 {
+	size := pathSize(cfg, path)
+	if size == 0 {
+		logf(cfg.Output, "[skip] %s (absent or empty)", label)
+		return 0
+	}
+	if cfg.DryRun {
+		logf(cfg.Output, "[plan] %s (%s)", label, formatBytes(size))
+		return size
+	}
+	logf(cfg.Output, "[plan] %s (%s)", label, formatBytes(size))
+	if err := cfg.FS.RemoveAll(path); err != nil {
+		logf(cfg.Output, "warning: %v", err)
+		return 0
+	}
+	logf(cfg.Output, "[done] %s (%s reclaimed)", label, formatBytes(size))
+	return size
+}
+
+// removeGlob expands the pattern and removes every match.
+func removeGlob(cfg CleanupConfig, pattern, label string) int64 {
+	matches, err := cfg.FS.Glob(pattern)
+	if err != nil {
+		logf(cfg.Output, "warning: glob %s: %v", pattern, err)
+		return 0
+	}
+	if len(matches) == 0 {
+		logf(cfg.Output, "[skip] %s (no matches)", label)
+		return 0
+	}
+	var reclaimed int64
+	for _, match := range matches {
+		reclaimed += removePath(cfg, match, match)
+	}
+	return reclaimed
+}
+
+// keepLatestVersion removes every child of dir except the one with the
+// highest natural-order version. Children may be directories (cursor-agent)
+// or regular files (claude, whose "versions" are named single-file binaries).
+func keepLatestVersion(cfg CleanupConfig, dir, label string) int64 {
+	entries, err := cfg.FS.ReadDir(dir)
+	if err != nil {
+		logf(cfg.Output, "[skip] %s (absent)", label)
+		return 0
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if len(names) <= 1 {
+		logf(cfg.Output, "[skip] %s (only %d version present)", label, len(names))
+		return 0
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return compareVersions(names[i], names[j]) < 0
+	})
+	latest := names[len(names)-1]
+	var reclaimed int64
+	for _, name := range names {
+		if name == latest {
+			continue
+		}
+		target := filepath.Join(dir, name)
+		reclaimed += removePath(cfg, target, label+": "+name)
+	}
+	if !cfg.DryRun {
+		logf(cfg.Output, "[done] %s (kept %s)", label, latest)
+	}
+	return reclaimed
+}
+
+// runTool invokes a tool-native cleaner via Runner. Skips with a log line if
+// the binary is missing from PATH. Respects dry-run mode.
+func runTool(cfg CleanupConfig, label, bin string, args ...string) {
+	if !cfg.hasBinary(bin) {
+		logf(cfg.Output, "[skip] %s (%s not on PATH)", label, bin)
+		return
+	}
+	if cfg.DryRun {
+		logf(cfg.Output, "[plan] %s", label)
+		return
+	}
+	logf(cfg.Output, "[plan] %s", label)
+	if err := cfg.Runner.Run(bin, args...); err != nil {
+		logf(cfg.Output, "warning: %s: %v", label, err)
+		return
+	}
+	logf(cfg.Output, "[done] %s", label)
+}
+
+// pathSize returns the total size of a path in bytes via `du -sb`. Returns 0
+// if the path does not exist or du fails.
+func pathSize(cfg CleanupConfig, path string) int64 {
+	raw, err := cfg.Runner.Output("du", "-sb", path)
+	if err != nil {
+		return 0
+	}
+	parts := strings.SplitN(strings.TrimSpace(raw), "\t", duFieldCount)
+	if len(parts) == 0 {
+		return 0
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// compareVersions performs natural-order comparison of version-like strings.
+// Parts separated by '.' or '-' are compared numerically when both parts are
+// numeric, and lexicographically otherwise. Returns -1, 0, or 1.
+func compareVersions(a, b string) int {
+	partsA := splitVersion(a)
+	partsB := splitVersion(b)
+	n := min(len(partsB), len(partsA))
+	for i := range n {
+		ai, aerr := strconv.Atoi(partsA[i])
+		bi, berr := strconv.Atoi(partsB[i])
+		if aerr == nil && berr == nil {
+			if ai != bi {
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+			continue
+		}
+		if partsA[i] != partsB[i] {
+			if partsA[i] < partsB[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	if len(partsA) != len(partsB) {
+		if len(partsA) < len(partsB) {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func splitVersion(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == '.' || r == '-'
+	})
+	return fields
+}

--- a/internal/system/cleanup_test.go
+++ b/internal/system/cleanup_test.go
@@ -53,10 +53,22 @@ func newCleanupHarness() *cleanupHarness {
 	return harness
 }
 
-// withPath marks a path as present with the given size.
+// withPath marks a path as present with the given size. The presence is
+// wired into the FS stub's Lstat so the cleanup code treats the path as
+// existing; the size is served back through the `du` stub.
 func (h *cleanupHarness) withPath(path string, size int64) *cleanupHarness {
 	h.sizes[path] = size
 	h.present[path] = true
+	h.fs = h.fs.WithPresentPath(path)
+	return h
+}
+
+// markPresent registers a path as existing without configuring a size.
+// Used to verify that zero-byte files (or paths where `du` is unavailable)
+// are still removed.
+func (h *cleanupHarness) markPresent(path string) *cleanupHarness {
+	h.present[path] = true
+	h.fs = h.fs.WithPresentPath(path)
 	return h
 }
 
@@ -352,6 +364,66 @@ func TestRunCleanup(t *testing.T) {
 		assert.Contains(t, h.fs.RemovedAll, hstsPath)
 		assert.Contains(t, h.fs.RemovedAll, zcdA)
 		assert.Contains(t, h.fs.RemovedAll, zcdB)
+	})
+
+	t.Run("should remove zero-byte files that exist on disk", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		// `.wget-hsts` is often created empty; the cleanup code must still
+		// remove it rather than treating zero size as "absent".
+		hstsPath := filepath.Join(home, ".wget-hsts")
+		h := newCleanupHarness().markPresent(hstsPath)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.fs.RemovedAll, hstsPath,
+			"zero-byte files must still be removed (du size == 0 is not absence)")
+	})
+
+	t.Run("should log a warning when version directory is unreadable", func(t *testing.T) {
+		t.Parallel()
+		// given — a permission error from ReadDir must not be reported as "absent".
+		home := testHome
+		versionsDir := filepath.Join(home, ".local/share/claude/versions")
+		h := newCleanupHarness()
+		h.fs = h.fs.WithReadDirError(versionsDir, errors.New("permission denied"))
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(),
+			"warning: reading claude agent versions: permission denied",
+			"unreadable directories should surface the real error, not a misleading skip")
+		assert.NotContains(t, h.buf.String(), "[skip] claude agent versions (absent)")
+	})
+
+	t.Run("should log a warning when du fails on a present path", func(t *testing.T) {
+		t.Parallel()
+		// given — the path exists but `du` cannot be executed (e.g. missing binary).
+		home := testHome
+		hstsPath := filepath.Join(home, ".wget-hsts")
+		h := newCleanupHarness().markPresent(hstsPath)
+		h.runner.OutputFunc = func(name string, args ...string) (string, error) {
+			if name == "du" && len(args) >= 2 && args[1] == hstsPath {
+				return "", errors.New("du: command not found")
+			}
+			return "", nil
+		}
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "warning: du "+hstsPath+": du: command not found")
+		assert.Contains(t, h.fs.RemovedAll, hstsPath,
+			"the file should still be removed even when size reporting fails")
 	})
 
 	t.Run("should skip JetBrains per-product loop when readdir returns no entries", func(t *testing.T) {

--- a/internal/system/cleanup_test.go
+++ b/internal/system/cleanup_test.go
@@ -1,0 +1,372 @@
+package system_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/devforge/internal/system"
+	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+)
+
+// testHome is the synthetic home directory used by every cleanup harness.
+const testHome = "/home/testuser"
+
+// cleanupHarness bundles the test doubles and sizing map used by RunCleanup
+// tests. Each test constructs its own harness so sub-tests can run in parallel.
+type cleanupHarness struct {
+	fs      *doubles.FileSystemStub
+	runner  *doubles.SystemRunnerStub
+	sizes   map[string]int64
+	buf     *bytes.Buffer
+	present map[string]bool
+}
+
+func newCleanupHarness() *cleanupHarness {
+	harness := &cleanupHarness{
+		fs:      doubles.NewFileSystemStub().WithHomeDir(testHome),
+		runner:  doubles.NewSystemRunnerStub(),
+		sizes:   map[string]int64{},
+		buf:     &bytes.Buffer{},
+		present: map[string]bool{},
+	}
+	// `du -sb <path>` is the sole size source used by cleanup.go. Route it
+	// through the sizes map so tests can declare which paths "exist".
+	harness.runner.OutputFunc = func(name string, args ...string) (string, error) {
+		if name != "du" || len(args) < 2 || args[0] != "-sb" {
+			return "", nil
+		}
+		path := args[1]
+		size, ok := harness.sizes[path]
+		if !ok {
+			return "", errors.New("no such file or directory")
+		}
+		return fmt.Sprintf("%d\t%s", size, path), nil
+	}
+	return harness
+}
+
+// withPath marks a path as present with the given size.
+func (h *cleanupHarness) withPath(path string, size int64) *cleanupHarness {
+	h.sizes[path] = size
+	h.present[path] = true
+	return h
+}
+
+func (h *cleanupHarness) config(dryRun bool, lookPath func(string) bool) system.CleanupConfig {
+	return system.CleanupConfig{
+		Runner:   h.runner,
+		FS:       h.fs,
+		DryRun:   dryRun,
+		Output:   h.buf,
+		LookPath: lookPath,
+	}
+}
+
+// noBinaries reports that no tool-native cleaners are available. Tests use
+// this to force the fallback direct-removal path in each category.
+func noBinaries(_ string) bool { return false }
+
+func TestRunCleanup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return error when home directory cannot be determined", func(t *testing.T) {
+		t.Parallel()
+		// given
+		fs := doubles.NewFileSystemStub().WithHomeDirError(errors.New("no home"))
+		runner := doubles.NewSystemRunnerStub()
+		var buf bytes.Buffer
+
+		// when
+		err := system.RunCleanup(system.CleanupConfig{
+			Runner:   runner,
+			FS:       fs,
+			Output:   &buf,
+			LookPath: noBinaries,
+		})
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting home directory")
+	})
+
+	t.Run("should report plan lines and not remove anything when dry-run enabled", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		h := newCleanupHarness().
+			withPath(filepath.Join(home, ".cache/JetBrains/RemoteDev/dist"), 9_600_000_000).
+			withPath(filepath.Join(home, ".cache/golangci-lint"), 5_100_000)
+
+		// when
+		err := system.RunCleanup(h.config(true, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "(dry-run mode)")
+		assert.Contains(t, h.buf.String(), "[plan] .cache/JetBrains/RemoteDev/dist")
+		assert.Contains(t, h.buf.String(), "[plan] .cache/golangci-lint")
+		assert.Contains(t, h.buf.String(), "dry-run total (would reclaim)")
+		assert.Empty(t, h.fs.RemovedAll, "dry-run must not call RemoveAll")
+	})
+
+	t.Run("should call RemoveAll for each present path when not dry-run", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		jbPath := filepath.Join(home, ".cache/JetBrains/RemoteDev/dist")
+		lintPath := filepath.Join(home, ".cache/golangci-lint")
+		h := newCleanupHarness().
+			withPath(jbPath, 9_600_000_000).
+			withPath(lintPath, 5_100_000)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.fs.RemovedAll, jbPath)
+		assert.Contains(t, h.fs.RemovedAll, lintPath)
+		assert.Contains(t, h.buf.String(), "[done] .cache/JetBrains/RemoteDev/dist")
+		assert.Contains(t, h.buf.String(), "reclaimed: ")
+	})
+
+	t.Run("should log [skip] and not remove absent paths", func(t *testing.T) {
+		t.Parallel()
+		// given
+		h := newCleanupHarness() // no withPath calls -- every path is absent
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "[skip] .cache/JetBrains/RemoteDev/dist")
+		assert.Contains(t, h.buf.String(), "[skip] .gradle/caches")
+		assert.Empty(t, h.fs.RemovedAll)
+	})
+
+	t.Run("should invoke go clean when go binary is available", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		goCachePath := filepath.Join(home, ".cache/go-build")
+		goModPath := filepath.Join(home, "go/pkg/mod")
+		h := newCleanupHarness().
+			withPath(goCachePath, 568_000_000).
+			withPath(goModPath, 12_000_000_000)
+		hasGo := func(bin string) bool { return bin == "go" }
+		var goCalls []string
+		h.runner.RunFunc = func(name string, args ...string) error {
+			if name == "go" {
+				goCalls = append(goCalls, strings.Join(args, " "))
+			}
+			return nil
+		}
+
+		// when
+		err := system.RunCleanup(h.config(false, hasGo))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, goCalls, "clean -cache")
+		assert.Contains(t, goCalls, "clean -modcache")
+		assert.Contains(t, goCalls, "clean -testcache")
+		// The direct rm fallback on go/pkg/mod should NOT fire when go is available.
+		assert.NotContains(t, h.fs.RemovedAll, goModPath)
+	})
+
+	t.Run("should fall back to direct removal when go binary is missing", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		goCachePath := filepath.Join(home, ".cache/go-build")
+		goModPath := filepath.Join(home, "go/pkg/mod")
+		h := newCleanupHarness().
+			withPath(goCachePath, 568_000_000).
+			withPath(goModPath, 12_000_000_000)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.fs.RemovedAll, goCachePath)
+		assert.Contains(t, h.fs.RemovedAll, goModPath)
+		// The "gradle --stop" entry exercises the runTool skip path while the
+		// Go category uses the silent fallback branch.
+		assert.Contains(t, h.buf.String(), "[skip] gradle --stop (gradle not on PATH)")
+	})
+
+	t.Run("should invoke terra clear --global when terra binary is available", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		terraPath := filepath.Join(home, ".cache/terra")
+		h := newCleanupHarness().withPath(terraPath, 3_900_000_000)
+		hasTerra := func(bin string) bool { return bin == "terra" }
+		var terraCalls [][]string
+		h.runner.RunFunc = func(name string, args ...string) error {
+			if name == "terra" {
+				terraCalls = append(terraCalls, args)
+			}
+			return nil
+		}
+
+		// when
+		err := system.RunCleanup(h.config(false, hasTerra))
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, terraCalls, 1)
+		assert.Equal(t, []string{"clear", "--global"}, terraCalls[0])
+	})
+
+	t.Run("should continue cleaning remaining categories after a RemoveAll failure", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		failingPath := filepath.Join(home, ".cache/JetBrains/RemoteDev/dist")
+		goodPath := filepath.Join(home, ".cache/golangci-lint")
+		h := newCleanupHarness().
+			withPath(failingPath, 9_600_000_000).
+			withPath(goodPath, 5_100_000)
+		h.fs = h.fs.WithRemoveAllError(failingPath, errors.New("permission denied"))
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "warning: permission denied")
+		assert.Contains(t, h.fs.RemovedAll, goodPath,
+			"later categories must still run after an earlier failure")
+	})
+
+	t.Run("should keep only the latest claude agent version", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		versionsDir := filepath.Join(home, ".local/share/claude/versions")
+		h := newCleanupHarness()
+		// Mixed-width semver — ensures natural-order, not lexicographic, sort.
+		// Claude stores each "version" as a regular binary file (EntryIsDir:false),
+		// not a directory, so this case is the file-based child scenario.
+		versions := []string{"2.1.90", "2.1.104", "2.1.107", "2.1.108"}
+		entries := make([]os.DirEntry, 0, len(versions))
+		for _, v := range versions {
+			entries = append(entries, &doubles.FakeDirEntry{EntryName: v, EntryIsDir: false})
+			h.withPath(filepath.Join(versionsDir, v), 200_000_000)
+		}
+		h.fs = h.fs.WithReadDir(versionsDir, entries)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		// The oldest three should be removed; 2.1.108 (latest) kept.
+		assert.Contains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2.1.90"))
+		assert.Contains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2.1.104"))
+		assert.Contains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2.1.107"))
+		assert.NotContains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2.1.108"))
+		assert.Contains(t, h.buf.String(), "kept 2.1.108")
+	})
+
+	t.Run("should keep only the latest cursor-agent date-style version", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		versionsDir := filepath.Join(home, ".local/share/cursor-agent/versions")
+		h := newCleanupHarness()
+		// Date-style identifiers with a git SHA suffix — the natural-order
+		// comparator must fall back to lex comparison when the pieces are
+		// non-numeric but maintain numeric ordering on the date segments.
+		versions := []string{
+			"2026.01.28-fd13201",
+			"2026.02.13-41ac335",
+			"2026.03.11-6dfa30c",
+			"2026.03.25-933d5a6",
+		}
+		entries := make([]os.DirEntry, 0, len(versions))
+		for _, v := range versions {
+			entries = append(entries, &doubles.FakeDirEntry{EntryName: v, EntryIsDir: true})
+			h.withPath(filepath.Join(versionsDir, v), 160_000_000)
+		}
+		h.fs = h.fs.WithReadDir(versionsDir, entries)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "kept 2026.03.25-933d5a6")
+		assert.Contains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2026.01.28-fd13201"))
+		assert.NotContains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2026.03.25-933d5a6"))
+	})
+
+	t.Run("should skip agent version cleanup when only one version is present", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		versionsDir := filepath.Join(home, ".local/share/claude/versions")
+		h := newCleanupHarness()
+		entries := []os.DirEntry{&doubles.FakeDirEntry{EntryName: "2.1.108", EntryIsDir: true}}
+		h.fs = h.fs.WithReadDir(versionsDir, entries).
+			WithReadDir(filepath.Join(home, ".local/share/cursor-agent/versions"), nil)
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.buf.String(), "[skip] claude agent versions (only 1 version present)")
+		assert.NotContains(t, h.fs.RemovedAll, filepath.Join(versionsDir, "2.1.108"))
+	})
+
+	t.Run("should delete .wget-hsts and all matching zcompdump glob entries", func(t *testing.T) {
+		t.Parallel()
+		// given
+		home := testHome
+		hstsPath := filepath.Join(home, ".wget-hsts")
+		zcdA := filepath.Join(home, ".zcompdump")
+		zcdB := filepath.Join(home, ".zcompdump-host-5.9")
+		h := newCleanupHarness().
+			withPath(hstsPath, 266).
+			withPath(zcdA, 52_000).
+			withPath(zcdB, 62_000)
+		h.fs = h.fs.WithGlob(filepath.Join(home, ".zcompdump*"), []string{zcdA, zcdB})
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, h.fs.RemovedAll, hstsPath)
+		assert.Contains(t, h.fs.RemovedAll, zcdA)
+		assert.Contains(t, h.fs.RemovedAll, zcdB)
+	})
+
+	t.Run("should skip JetBrains per-product loop when readdir returns no entries", func(t *testing.T) {
+		t.Parallel()
+		// given
+		h := newCleanupHarness() // no JetBrains children
+
+		// when
+		err := system.RunCleanup(h.config(false, noBinaries))
+
+		// then
+		require.NoError(t, err)
+		// The single RemoteDev/dist plan line is the only JetBrains log we expect.
+		assert.Contains(t, h.buf.String(), "[skip] .cache/JetBrains/RemoteDev/dist")
+		// No per-product sub-directories should appear.
+		assert.NotContains(t, h.buf.String(), "GoLand")
+	})
+}

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -21,6 +21,7 @@ type Runner interface {
 type FileSystem interface {
 	Remove(path string) error
 	RemoveAll(path string) error
+	Lstat(path string) (os.FileInfo, error)
 	Glob(pattern string) ([]string, error)
 	UserHomeDir() (string, error)
 	ReadDir(dir string) ([]os.DirEntry, error)
@@ -65,12 +66,11 @@ func (f *DefaultFileSystem) Remove(path string) error {
 }
 
 func (f *DefaultFileSystem) RemoveAll(path string) error {
-	err := os.RemoveAll(path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
+	// os.RemoveAll already returns nil when the path does not exist, so no
+	// extra ErrNotExist guard is needed (see doc on [os.RemoveAll]).
+	return os.RemoveAll(path)
 }
+func (f *DefaultFileSystem) Lstat(path string) (os.FileInfo, error)    { return os.Lstat(path) }
 func (f *DefaultFileSystem) Glob(pattern string) ([]string, error)     { return filepath.Glob(pattern) }
 func (f *DefaultFileSystem) UserHomeDir() (string, error)              { return os.UserHomeDir() }
 func (f *DefaultFileSystem) ReadDir(dir string) ([]os.DirEntry, error) { return os.ReadDir(dir) }

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -20,6 +20,7 @@ type Runner interface {
 // FileSystem abstracts filesystem operations for testability.
 type FileSystem interface {
 	Remove(path string) error
+	RemoveAll(path string) error
 	Glob(pattern string) ([]string, error)
 	UserHomeDir() (string, error)
 	ReadDir(dir string) ([]os.DirEntry, error)
@@ -57,6 +58,14 @@ type DefaultFileSystem struct{}
 
 func (f *DefaultFileSystem) Remove(path string) error {
 	err := os.Remove(path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (f *DefaultFileSystem) RemoveAll(path string) error {
+	err := os.RemoveAll(path)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		return nil
 	}

--- a/internal/testutil/doubles/file_system_stub.go
+++ b/internal/testutil/doubles/file_system_stub.go
@@ -9,18 +9,26 @@ import (
 // FileSystemStub is a test double for system.FileSystem with configurable behavior.
 type FileSystemStub struct {
 	RemoveFunc      func(path string) error
+	RemoveAllFunc   func(path string) error
 	GlobFunc        func(pattern string) ([]string, error)
 	UserHomeDirFunc func() (string, error)
 	ReadDirFunc     func(dir string) ([]os.DirEntry, error)
+	// RemovedAll records every path passed to RemoveAll, in call order.
+	RemovedAll []string
 }
 
 func NewFileSystemStub() *FileSystemStub {
-	return &FileSystemStub{
+	stub := &FileSystemStub{
 		RemoveFunc:      func(_ string) error { return nil },
 		GlobFunc:        func(_ string) ([]string, error) { return nil, nil },
 		UserHomeDirFunc: func() (string, error) { return "/home/testuser", nil },
 		ReadDirFunc:     func(_ string) ([]os.DirEntry, error) { return nil, nil },
 	}
+	stub.RemoveAllFunc = func(path string) error {
+		stub.RemovedAll = append(stub.RemovedAll, path)
+		return nil
+	}
+	return stub
 }
 
 func (s *FileSystemStub) WithHomeDir(dir string) *FileSystemStub {
@@ -66,6 +74,17 @@ func (s *FileSystemStub) WithRemoveError(path string, err error) *FileSystemStub
 	return s
 }
 
+func (s *FileSystemStub) WithRemoveAllError(path string, err error) *FileSystemStub {
+	prev := s.RemoveAllFunc
+	s.RemoveAllFunc = func(p string) error {
+		if p == path {
+			return err
+		}
+		return prev(p)
+	}
+	return s
+}
+
 func (s *FileSystemStub) WithReadDir(dir string, entries []os.DirEntry) *FileSystemStub {
 	prev := s.ReadDirFunc
 	s.ReadDirFunc = func(d string) ([]os.DirEntry, error) {
@@ -89,6 +108,7 @@ func (s *FileSystemStub) WithReadDirError(dir string, err error) *FileSystemStub
 }
 
 func (s *FileSystemStub) Remove(path string) error                  { return s.RemoveFunc(path) }
+func (s *FileSystemStub) RemoveAll(path string) error               { return s.RemoveAllFunc(path) }
 func (s *FileSystemStub) Glob(pattern string) ([]string, error)     { return s.GlobFunc(pattern) }
 func (s *FileSystemStub) UserHomeDir() (string, error)              { return s.UserHomeDirFunc() }
 func (s *FileSystemStub) ReadDir(dir string) ([]os.DirEntry, error) { return s.ReadDirFunc(dir) }

--- a/internal/testutil/doubles/file_system_stub.go
+++ b/internal/testutil/doubles/file_system_stub.go
@@ -10,6 +10,7 @@ import (
 type FileSystemStub struct {
 	RemoveFunc      func(path string) error
 	RemoveAllFunc   func(path string) error
+	LstatFunc       func(path string) (os.FileInfo, error)
 	GlobFunc        func(pattern string) ([]string, error)
 	UserHomeDirFunc func() (string, error)
 	ReadDirFunc     func(dir string) ([]os.DirEntry, error)
@@ -20,6 +21,7 @@ type FileSystemStub struct {
 func NewFileSystemStub() *FileSystemStub {
 	stub := &FileSystemStub{
 		RemoveFunc:      func(_ string) error { return nil },
+		LstatFunc:       func(_ string) (os.FileInfo, error) { return nil, os.ErrNotExist },
 		GlobFunc:        func(_ string) ([]string, error) { return nil, nil },
 		UserHomeDirFunc: func() (string, error) { return "/home/testuser", nil },
 		ReadDirFunc:     func(_ string) ([]os.DirEntry, error) { return nil, nil },
@@ -85,6 +87,35 @@ func (s *FileSystemStub) WithRemoveAllError(path string, err error) *FileSystemS
 	return s
 }
 
+// WithPresentPath marks a path as present on the stub's Lstat calls. The
+// returned FileInfo is minimal -- callers that need richer metadata should
+// use [FileSystemStub.WithLstat] instead.
+func (s *FileSystemStub) WithPresentPath(path string) *FileSystemStub {
+	return s.WithLstat(path, &fakeFileInfo{name: path})
+}
+
+func (s *FileSystemStub) WithLstat(path string, info os.FileInfo) *FileSystemStub {
+	prev := s.LstatFunc
+	s.LstatFunc = func(p string) (os.FileInfo, error) {
+		if p == path {
+			return info, nil
+		}
+		return prev(p)
+	}
+	return s
+}
+
+func (s *FileSystemStub) WithLstatError(path string, err error) *FileSystemStub {
+	prev := s.LstatFunc
+	s.LstatFunc = func(p string) (os.FileInfo, error) {
+		if p == path {
+			return nil, err
+		}
+		return prev(p)
+	}
+	return s
+}
+
 func (s *FileSystemStub) WithReadDir(dir string, entries []os.DirEntry) *FileSystemStub {
 	prev := s.ReadDirFunc
 	s.ReadDirFunc = func(d string) ([]os.DirEntry, error) {
@@ -109,6 +140,7 @@ func (s *FileSystemStub) WithReadDirError(dir string, err error) *FileSystemStub
 
 func (s *FileSystemStub) Remove(path string) error                  { return s.RemoveFunc(path) }
 func (s *FileSystemStub) RemoveAll(path string) error               { return s.RemoveAllFunc(path) }
+func (s *FileSystemStub) Lstat(path string) (os.FileInfo, error)    { return s.LstatFunc(path) }
 func (s *FileSystemStub) Glob(pattern string) ([]string, error)     { return s.GlobFunc(pattern) }
 func (s *FileSystemStub) UserHomeDir() (string, error)              { return s.UserHomeDirFunc() }
 func (s *FileSystemStub) ReadDir(dir string) ([]os.DirEntry, error) { return s.ReadDirFunc(dir) }


### PR DESCRIPTION
## Summary

- Adds `dev system cleanup` — a new command under the `system` group that reclaims disk space across Go, Node, Python, Gradle, JetBrains, Terra, SDKMAN, and Claude/cursor-agent binary versions, while preserving credentials, shell history, and installed SDK runtimes.
- Dry-run on the author's home reclaims **~35.7 GB**. `--dry-run` flag mirrors the existing `clear-history` / `clear-logs` commands.
- Uses tool-native cleaners when available (`go clean -modcache`, `terra clear --global`, `gradle --stop`, `npm cache clean --force`, `pip cache purge`) with direct fallback when the binary is missing.
- Extends the `FileSystem` interface with `RemoveAll` (required for recursive directory removal); `FileSystemStub` tracks removed paths for assertions.

## Command surface

```
dev system cleanup [--dry-run]
```

Categories run sequentially; a failure in one does not abort the others (matches `RunClearHistory` philosophy). Prints `[plan]` / `[done]` / `[skip]` lines per path plus a final reclaimed-size summary. Keeps only the natural-order latest child under `.local/share/claude/versions` and `.local/share/cursor-agent/versions` — correctly handling both file-based (claude) and directory-based (cursor-agent) children.

## Preservation

Never touched: `.ssh`, `.gnupg`, `.pki`, `.aws`, `.azure`, `.kube`, `.docker`, `.gitconfig`, `.npmrc`, `.claude.json`, `.claude/settings*.json`, `.claude/rules`, `.claude/agents`, `.claude/commands`, `.claude/projects` (conversation history), `.config/gh`, `.config/github-copilot`, `.histdb`, `.zsh_history`, `.pyenv/versions`, `.nvm/versions`, `.gvm/gos`, `.sdkman/candidates`, `.m2`.

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass; 13 new BDD tests in `cleanup_test.go` cover dry-run, direct removal, tool-native cleaners, error propagation, JetBrains per-product loop, and version pruning for both file- and directory-based children
- [x] `make sast` — Trivy 0 findings, Shellcheck only flags pre-existing `install.sh` POSIX warnings (unrelated)
- [x] `./bin/dev system cleanup --help` — help text renders
- [x] `./bin/dev system cleanup --dry-run` — plans 35.7 GB reclaim on real `$HOME`, every path resolves correctly, Claude versions and cursor-agent versions both detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)