### PR TITLE
fix(gvm): guard gvm use against uninstalled or 2-segment Go versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - fixed `dev project use` emitting `gvm use go<X.Y>` for 2-segment `go.mod` directives (e.g. `go 1.26`), which gvm rejects with a misleading "It doesn't look like Go has been installed" error -- the command now resolves the highest installed patch via `gvm list` and falls back to a clean `[dev]` install hint when no match exists
 - fixed `dev project use` producing the same misleading gvm error when the exact 3-segment Go version from `go.mod` is not yet installed -- the command now guards the `gvm use` call with a presence check and prints a `[dev] gvm install go<version>` hint instead
+- fixed `dev project use` emitting an install hint containing unescaped `<patch>` placeholder that would break when copy-pasted into a shell due to `<`/`>` redirection parsing -- the hint now points users to `gvm listall | grep '^go<X.Y>\.'` so they can pick a valid patch version
+- fixed `dev project use` leaking the internal `_dev_go` helper variable into the caller's shell after `eval` -- the emitted command now `unset`s it once the switch or hint has run
 
 ## [0.7.3] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `dev project use` emitting `gvm use go<X.Y>` for 2-segment `go.mod` directives (e.g. `go 1.26`), which gvm rejects with a misleading "It doesn't look like Go has been installed" error -- the command now resolves the highest installed patch via `gvm list` and falls back to a clean `[dev]` install hint when no match exists
+- fixed `dev project use` producing the same misleading gvm error when the exact 3-segment Go version from `go.mod` is not yet installed -- the command now guards the `gvm use` call with a presence check and prints a `[dev] gvm install go<version>` hint instead
+
 ## [0.7.3] - 2026-04-19
 
 ### Changed

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -136,22 +136,49 @@ func extractPythonSDKVersion(content string) string {
 
 // buildUseCommand returns the shell command to switch to a specific SDK version.
 func buildUseCommand(versionManager, language, version string) string {
-	type cmdTemplate struct {
-		format string
-	}
-	templates := map[string]cmdTemplate{
-		"gvm":    {"gvm use go%s"},
-		"nvm":    {"nvm use %s"},
-		"pyenv":  {"pyenv local %s"},
-		"sdkman": {"sdk use java %s"},
+	builders := map[string]func(string) string{
+		"gvm":    buildGvmUseCommand,
+		"nvm":    func(v string) string { return fmt.Sprintf("nvm use %s", v) },
+		"pyenv":  func(v string) string { return fmt.Sprintf("pyenv local %s", v) },
+		"sdkman": func(v string) string { return fmt.Sprintf("sdk use java %s", v) },
 	}
 
-	tmpl, ok := templates[versionManager]
+	build, ok := builders[versionManager]
 	if !ok {
 		return ""
 	}
 	_ = language // reserved for future use
-	return fmt.Sprintf(tmpl.format, version)
+	return build(version)
+}
+
+var twoSegmentGoVersionRe = regexp.MustCompile(`^\d+\.\d+$`)
+
+// buildGvmUseCommand emits eval-ready shell that safely switches Go via gvm.
+// gvm only accepts exact installed tags (e.g. "go1.26.3"), which fails in two
+// common scenarios:
+//   - go.mod uses a 2-segment directive like "go 1.26" — no matching tag exists
+//   - the exact patch in go.mod is not installed
+//
+// Both cases produce the misleading "It doesn't look like Go has been installed"
+// message from gvm. We resolve installed tags via `gvm list` at eval time: for
+// 2-segment versions we pick the highest matching patch; for 3-segment we check
+// exact presence. When no match is found, we print a "[dev]" install hint and
+// skip the `gvm use` call entirely so gvm's error cannot surface.
+func buildGvmUseCommand(version string) string {
+	if twoSegmentGoVersionRe.MatchString(version) {
+		pattern := fmt.Sprintf(`^go%s(\.[0-9]+)?$`, regexp.QuoteMeta(version))
+		return fmt.Sprintf(
+			`_dev_go=$(gvm list 2>/dev/null | awk '{print $NF}' | grep -E '%s' | sort -V | tail -n1); `+
+				`if [ -n "$_dev_go" ]; then gvm use "$_dev_go"; `+
+				`else echo "[dev] no installed Go matching %s -- run: gvm install go%s.<patch>" >&2; fi`,
+			pattern, version, version,
+		)
+	}
+	return fmt.Sprintf(
+		`if gvm list 2>/dev/null | awk '{print $NF}' | grep -qxF go%s; then gvm use go%s; `+
+			`else echo "[dev] go%s is not installed -- run: gvm install go%s" >&2; fi`,
+		version, version, version, version,
+	)
 }
 
 func resolveRepoPath(path string) (string, error) {

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -170,7 +170,8 @@ func buildGvmUseCommand(version string) string {
 		return fmt.Sprintf(
 			`_dev_go=$(gvm list 2>/dev/null | awk '{print $NF}' | grep -E '%s' | sort -V | tail -n1); `+
 				`if [ -n "$_dev_go" ]; then gvm use "$_dev_go"; `+
-				`else echo "[dev] no installed Go matching %s -- run: gvm install go%s.<patch>" >&2; fi`,
+				`else echo "[dev] no installed Go matching %s -- run: gvm listall | grep '^go%s\\.'" >&2; fi; `+
+				`unset _dev_go`,
 			pattern, version, version,
 		)
 	}

--- a/internal/project/detect_internal_test.go
+++ b/internal/project/detect_internal_test.go
@@ -23,7 +23,8 @@ func TestBuildGvmUseCommand(t *testing.T) {
 		assert.Contains(t, cmd, `sort -V | tail -n1`)
 		assert.Contains(t, cmd, `gvm use "$_dev_go"`)
 		assert.Contains(t, cmd, `[dev] no installed Go matching 1.26`)
-		assert.Contains(t, cmd, `gvm install go1.26.<patch>`)
+		assert.Contains(t, cmd, `gvm listall | grep '^go1.26\\.'`)
+		assert.Contains(t, cmd, `unset _dev_go`)
 	})
 
 	t.Run("should guard exact tag when version is 3-segment", func(t *testing.T) {

--- a/internal/project/detect_internal_test.go
+++ b/internal/project/detect_internal_test.go
@@ -1,0 +1,108 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildGvmUseCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should resolve highest installed patch when version is 2-segment", func(t *testing.T) {
+		t.Parallel()
+		// given
+		version := "1.26"
+
+		// when
+		cmd := buildGvmUseCommand(version)
+
+		// then
+		assert.Contains(t, cmd, `gvm list 2>/dev/null`)
+		assert.Contains(t, cmd, `grep -E '^go1\.26(\.[0-9]+)?$'`)
+		assert.Contains(t, cmd, `sort -V | tail -n1`)
+		assert.Contains(t, cmd, `gvm use "$_dev_go"`)
+		assert.Contains(t, cmd, `[dev] no installed Go matching 1.26`)
+		assert.Contains(t, cmd, `gvm install go1.26.<patch>`)
+	})
+
+	t.Run("should guard exact tag when version is 3-segment", func(t *testing.T) {
+		t.Parallel()
+		// given
+		version := "1.26.1"
+
+		// when
+		cmd := buildGvmUseCommand(version)
+
+		// then
+		assert.Contains(t, cmd, `grep -qxF go1.26.1`)
+		assert.Contains(t, cmd, `gvm use go1.26.1`)
+		assert.Contains(t, cmd, `[dev] go1.26.1 is not installed`)
+		assert.Contains(t, cmd, `gvm install go1.26.1`)
+	})
+
+	t.Run("should produce shell that avoids calling gvm use when nothing matches", func(t *testing.T) {
+		t.Parallel()
+		// given
+		version := "1.99"
+
+		// when
+		cmd := buildGvmUseCommand(version)
+
+		// then
+		// The "else" branch must emit the hint and NOT contain a standalone `gvm use`
+		// call -- this is the bug the wrapper prevents.
+		assert.Contains(t, cmd, `else echo "[dev] no installed Go matching 1.99`)
+		assert.NotContains(t, cmd, `else gvm use`)
+	})
+}
+
+func TestBuildUseCommandDispatchesByManager(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should emit pyenv local for pyenv", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		cmd := buildUseCommand("pyenv", "python", "3.12.0")
+
+		// then
+		assert.Equal(t, "pyenv local 3.12.0", cmd)
+	})
+
+	t.Run("should emit nvm use for nvm", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		cmd := buildUseCommand("nvm", "node", "20.11.0")
+
+		// then
+		assert.Equal(t, "nvm use 20.11.0", cmd)
+	})
+
+	t.Run("should emit sdk use java for sdkman", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		cmd := buildUseCommand("sdkman", "java", "21-tem")
+
+		// then
+		assert.Equal(t, "sdk use java 21-tem", cmd)
+	})
+
+	t.Run("should delegate to gvm builder for gvm", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		cmd := buildUseCommand("gvm", "go", "1.26.0")
+
+		// then
+		assert.Contains(t, cmd, `grep -qxF go1.26.0`)
+		assert.Contains(t, cmd, `gvm use go1.26.0`)
+	})
+
+	t.Run("should return empty for unknown manager", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		cmd := buildUseCommand("unknown", "go", "1.26.0")
+
+		// then
+		assert.Empty(t, cmd)
+	})
+}


### PR DESCRIPTION
## Summary

- resolve the highest installed patch via `gvm list` when `go.mod` uses a 2-segment directive (e.g. `go 1.26`)
- presence-check exact 3-segment versions before calling `gvm use`, printing a clean `[dev] gvm install` hint on miss
- add internal BDD tests for `buildGvmUseCommand` and `buildUseCommand` dispatch

## Context

When a terminal opens in a Go project whose required version is missing or unresolvable by gvm, the previous `buildUseCommand` emitted a bare `gvm use go<version>`. gvm only accepts exact installed tags (e.g. `go1.26.3`), so two failure modes produced the same misleading error:

```
ERROR: It doesn't look like Go has been installed. Follow these steps to begin:
   1) Use 'gvm listall' to select a go version
   2) Use 'gvm install <version>' to install.
   3) Then use 'cd .' or 'gvm use <version>'.
```

1. **2-segment `go.mod`** like `go 1.26` — no `go1.26` tag exists, only `go1.26.X` patches.
2. **3-segment `go.mod`** specifying a patch the user has not installed.

### Before / After

For `fleet-maintenance` (`go 1.26` in `go.mod`), with only `go1.25.5` installed via gvm:

Before (opening a new terminal):
```
ERROR: It doesn't look like Go has been installed. Follow these steps to begin:
       1) Use 'gvm listall' to select a go version
       2) Use 'gvm install <version>' to install.
       3) Then use 'cd .' or 'gvm use <version>'.
```

After:
```
[dev] no installed Go matching 1.26 -- run: gvm install go1.26.<patch>
```

No more spurious gvm error, and the current Go is left intact instead of being unset by a failed `gvm use` call.

## Test plan

- [x] `go test ./internal/project/...` — passes
- [x] manual eval of `dev project use` output in a repo with 2-segment `go.mod` and no matching patch installed — prints the `[dev]` hint, does not invoke `gvm use`
- [ ] manual eval after installing a matching `go1.X.Y` via gvm — picks the highest installed patch and switches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)