### PR TITLE
fix(prune): scan repositories recursively like sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `dev repo prune` only scanning the top-level directory (e.g. missing nested repos like `org/project/repo`) -- it now walks the directory tree recursively using `FindAllRepos`, matching the behavior of `dev repo sync`
+
 ## [0.7.4] - 2026-04-22
 
 ### Fixed

--- a/internal/repo/prune.go
+++ b/internal/repo/prune.go
@@ -27,7 +27,7 @@ func isPruneFailure(status string) bool {
 func RunPrune(rootDir string, runner GitRunner, dryRun bool, output io.Writer) error {
 	log := NewLogger(output)
 
-	repos := ScanFlatRepos(rootDir)
+	repos := FindAllRepos(rootDir)
 	total := len(repos)
 	if total == 0 {
 		log.WithField("dir", rootDir).Warn("no git repositories found")
@@ -44,14 +44,13 @@ func RunPrune(rootDir string, runner GitRunner, dryRun bool, output io.Writer) e
 	results := make([]PruneResult, total)
 	var wg sync.WaitGroup
 
-	for i, repoName := range repos {
+	for i, repoPath := range repos {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, name string) {
+		go func(idx int, path string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			repoPath := filepath.Join(rootDir, name)
-			result := PruneSingleRepo(repoPath, rootDir, runner, dryRun)
+			result := PruneSingleRepo(path, rootDir, runner, dryRun)
 			if len(result.Deleted) > 0 || isPruneFailure(result.Status) {
 				log.WithFields(logger.Fields{
 					"repo":   result.Name,
@@ -59,7 +58,7 @@ func RunPrune(rootDir string, runner GitRunner, dryRun bool, output io.Writer) e
 				}).Info("prune result")
 			}
 			results[idx] = result
-		}(i, repoName)
+		}(i, repoPath)
 	}
 
 	wg.Wait()

--- a/internal/repo/prune_test.go
+++ b/internal/repo/prune_test.go
@@ -209,4 +209,26 @@ func TestRunPrune(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, buf.String(), "clean=1")
 	})
+
+	t.Run("should discover and prune nested repositories recursively", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/project-a/repo-one")
+		createGitRepo(t, root+"/project-b/repo-two")
+		runner := doubles.NewGitRunnerStub().
+			WithOutput([]string{"symbolic-ref", "refs/remotes/origin/HEAD"}, "refs/remotes/origin/main").
+			WithOutput([]string{"branch", "--merged", "main"}, "  feat/old\n* main")
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunPrune(root, runner, false, &buf)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.NotContains(t, output, "no git repositories found")
+		assert.Contains(t, output, "count=2")
+		assert.Contains(t, output, "pruned=2")
+	})
 }


### PR DESCRIPTION
## Summary

- `dev repo prune` only scanned a single directory level via `ScanFlatRepos`, so nested layouts like `org/project/repo` (e.g. Azure DevOps trees under `~/Development/dev.azure.com/<org>`) produced `no git repositories found`.
- Switched `RunPrune` to `FindAllRepos`, the same recursive walker already used by `sync`, `mirror`, `restore`, and `failover`.
- Added a `CHANGELOG.md` entry under `[Unreleased] > Fixed`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/repo/... -run TestRunPrune -count=1`
- [x] `go test ./... -count=1`
- [ ] Manually run `dev repo prune ~/Development/dev.azure.com/<org>` against a nested workspace and verify repos are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)