### PR TITLE
feat(gist): add dev gist clone and sync commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `dev gist clone` command -- discovers GitHub gists for a user and clones missing ones via SSH in parallel, mirroring the directory structure `gist.github.com/<user>/<slug>` where `<slug>` is derived from the gist description (or the gist ID when blank)
+- added `dev gist sync` command -- fetches and rebases all gist repositories under a directory, preserving uncommitted work via WIP branches (same workflow as `dev repo sync`)
+- added `internal/gist` package with `Provider` interface, `GitHubProvider` implementation backed by `go-github`, slug derivation, scanner, and clone/sync orchestration
+- added `GistProviderStub` test double for unit testing the gist workflow
+
 ## [0.7.7] - 2026-04-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added `dev gist clone` command -- discovers GitHub gists for a user and clones missing ones via SSH in parallel, mirroring the directory structure `gist.github.com/<user>/<slug>` where `<slug>` is derived from the gist description (or the gist ID when blank)
-- added `dev gist sync` command -- fetches and rebases all gist repositories under a directory, preserving uncommitted work via WIP branches (same workflow as `dev repo sync`)
-- added `internal/gist` package with `Provider` interface, `GitHubProvider` implementation backed by `go-github`, slug derivation, scanner, and clone/sync orchestration
+- added `dev gist clone` command -- discovers GitHub gists for a user and clones missing ones via SSH in parallel, where the user-supplied root directory is the owner directory (`gist.github.com/<owner>`) and each gist lands at `<root-dir>/<slug>`. The slug is derived from the gist description (or the gist ID when blank); colliding slugs are disambiguated with a short ID suffix
+- added `dev gist sync` command -- fetches and rebases all gist repositories one level under the root directory, preserving uncommitted work via WIP branches (same workflow as `dev repo sync`)
+- added `internal/gist` package with `Provider` interface, `GitHubProvider` implementation backed by `go-github`, slug derivation, `AssignKeys` collision handling, scanner, and clone/sync orchestration
+- added `repo.SSHPreflightHost` for verifying SSH access to a host that is not registered in the provider registry (used by gist commands to preflight `gist.github.com`)
 - added `GistProviderStub` test double for unit testing the gist workflow
 
 ## [0.7.7] - 2026-04-28

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ dev repo prune ~/Development/github.com/rios0rios0 --dry-run    # preview withou
 dev repo mirror mine ~/Development/github.com/rios0rios0        # create Codeberg pull mirrors
 dev repo failover ~/Development/github.com/rios0rios0           # switch repos to Codeberg primary
 dev repo restore ~/Development/github.com/rios0rios0            # restore GitHub as primary remote
+dev gist clone mine ~/Development/gist.github.com/rios0rios0    # clone missing GitHub gists (slug from description)
+dev gist clone mine ~/Development/gist.github.com/rios0rios0 --dry-run # preview without cloning
+dev gist sync ~/Development/gist.github.com/rios0rios0          # sync all gists
 dev project info .                                              # detect language and show info
 dev project use .                                               # print version switch commands (eval it)
 dev project start .                                             # run project start command (with .dev.yaml deps)
@@ -99,6 +102,13 @@ internal/
     ips.go                   -- RunIPs: list container IP addresses
     reset.go                 -- RunReset: stop all containers, prune resources with dry-run support
     *_test.go                -- BDD tests
+  gist/
+    gist.go                  -- Gist entity, slug derivation, owner detection, SSH URL builder
+    provider.go              -- Provider interface + GitHubProvider (go-github gist API)
+    scanner.go               -- ScanLocalGists: walk <root>/<owner>/<slug> for .git directories
+    clone.go                 -- RunClone: discover, diff, parallel clone (reuses repo.GitRunner/SSHPreflight)
+    sync.go                  -- RunSync: delegates to repo.SyncSingleRepo for each gist
+    *_test.go                -- BDD tests
   system/
     runner.go                -- Runner interface (exec.Command wrapper for system commands)
     platform.go              -- platform detection (IsAndroid, IsLinux) via runtime.GOOS
@@ -108,7 +118,7 @@ internal/
     top5size.go              -- show top 5 largest items in a directory
     *_test.go                -- BDD tests
   testutil/
-    doubles/                 -- GitRunnerStub, ForgeProviderStub, ForkResolverStub, CommandRunnerStub, LanguageDetectorStub, LanguageDetectorMultiStub, ConfigReaderStub, DockerRunnerStub, FileSystemStub, MirrorProviderStub, SystemRunnerStub
+    doubles/                 -- GitRunnerStub, ForgeProviderStub, ForkResolverStub, GistProviderStub, CommandRunnerStub, LanguageDetectorStub, LanguageDetectorMultiStub, ConfigReaderStub, DockerRunnerStub, FileSystemStub, MirrorProviderStub, SystemRunnerStub
     builders/                -- RepositoryBuilder
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ DevForge is a developer workspace toolkit that manages Git repositories across m
 
 - **Repository Cloning**: discovers repos from GitHub, Azure DevOps, or GitLab and clones missing ones via SSH in parallel
 - **Repository Syncing**: fetches and rebases all repos under a directory, preserving uncommitted work via WIP branches
+- **Gist Cloning & Syncing**: discovers GitHub gists for a user, clones missing ones via SSH using a description-derived slug, and syncs them with the same WIP-aware workflow as repos
 - **Fork Syncing**: detects forked repos via provider API, syncs with upstream parent, and handles conflicts by creating reference branches
 - **Branch Pruning**: deletes local branches merged into the default branch across all repos
 - **Docker Management**: lists container IPs and resets the Docker environment (stop, prune)
@@ -57,6 +58,15 @@ dev repo fork-sync --dry-run     # preview without syncing
 # Delete local merged branches
 dev repo prune [root-dir]
 dev repo prune ~/Development/github.com/rios0rios0 --dry-run
+
+# Clone all GitHub gists for a user (slug derived from description; falls back to gist ID)
+dev gist clone <ssh-alias> [root-dir]
+dev gist clone mine ~/Development/gist.github.com/rios0rios0
+dev gist clone mine ~/Development/gist.github.com/rios0rios0 --dry-run
+
+# Sync all gists under a directory
+dev gist sync [root-dir]
+dev gist sync ~/Development/gist.github.com/rios0rios0
 
 # Docker environment management
 dev docker ips                  # list container IP addresses

--- a/cmd/devforge/main.go
+++ b/cmd/devforge/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rios0rios0/cliforge/pkg/selfupdate"
 	"github.com/rios0rios0/devforge/internal/docker"
+	"github.com/rios0rios0/devforge/internal/gist"
 	"github.com/rios0rios0/devforge/internal/project"
 	"github.com/rios0rios0/devforge/internal/repo"
 	"github.com/rios0rios0/devforge/internal/system"
@@ -73,6 +74,13 @@ func main() {
 	projectCmd.AddCommand(newProjectInfoCmd())
 	projectCmd.AddCommand(newProjectUseCmd())
 
+	gistCmd := &cobra.Command{
+		Use:   "gist",
+		Short: "GitHub gist management commands",
+	}
+	gistCmd.AddCommand(newGistCloneCmd())
+	gistCmd.AddCommand(newGistSyncCmd())
+
 	dockerCmd := &cobra.Command{
 		Use:   "docker",
 		Short: "Docker environment management commands",
@@ -92,6 +100,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(repoCmd)
+	rootCmd.AddCommand(gistCmd)
 	rootCmd.AddCommand(projectCmd)
 	rootCmd.AddCommand(dockerCmd)
 	rootCmd.AddCommand(systemCmd)
@@ -229,6 +238,71 @@ lists local branches merged into the default branch and deletes them.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show which branches would be deleted without deleting them")
 
 	return cmd
+}
+
+func newGistCloneCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "clone <ssh-alias> [root-dir]",
+		Short: "Clone missing GitHub gists for a user",
+		Long: `Discovers gists from GitHub for the owner inferred from the root path
+(.../gist.github.com/<owner>), compares with local directories, and clones
+missing gists via SSH. Each gist lands at <root-dir>/<owner>/<slug>, where
+the slug is derived from the gist description (or the gist ID when blank).`,
+		Args: cobra.RangeArgs(1, gist.MaxCloneArgs()),
+		RunE: func(_ *cobra.Command, args []string) error {
+			sshAlias := args[0]
+			rootDir, _ := os.Getwd()
+			if len(args) > 1 {
+				rootDir = args[1]
+			}
+			rootDir = filepath.Clean(rootDir)
+
+			owner, ownerErr := gist.DetectOwner(rootDir)
+			if ownerErr != nil {
+				return ownerErr
+			}
+
+			provider, providerErr := gist.ResolveProvider()
+			if providerErr != nil {
+				return providerErr
+			}
+
+			return gist.RunClone(gist.CloneConfig{
+				RootDir:  rootDir,
+				Owner:    owner,
+				SSHAlias: sshAlias,
+				DryRun:   dryRun,
+				Provider: provider,
+				Runner:   &repo.DefaultGitRunner{},
+				Output:   os.Stderr,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be done without making changes")
+
+	return cmd
+}
+
+func newGistSyncCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sync [root-dir]",
+		Short: "Sync all GitHub gists under a directory",
+		Long: `For each gist repository found under the root directory, fetches all
+remotes, rebases the default branch, and preserves uncommitted work via
+WIP commits (same workflow as 'dev repo sync').`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			rootDir, _ := os.Getwd()
+			if len(args) > 0 {
+				rootDir = args[0]
+			}
+			rootDir = filepath.Clean(rootDir)
+			return gist.RunSync(rootDir, &repo.DefaultGitRunner{}, os.Stderr)
+		},
+	}
 }
 
 func newProjectConfig(args []string) project.Config {

--- a/cmd/devforge/main.go
+++ b/cmd/devforge/main.go
@@ -248,8 +248,9 @@ func newGistCloneCmd() *cobra.Command {
 		Short: "Clone missing GitHub gists for a user",
 		Long: `Discovers gists from GitHub for the owner inferred from the root path
 (.../gist.github.com/<owner>), compares with local directories, and clones
-missing gists via SSH. Each gist lands at <root-dir>/<owner>/<slug>, where
-the slug is derived from the gist description (or the gist ID when blank).`,
+missing gists via SSH. Each gist lands directly under that directory at
+<root-dir>/<slug>, where the slug is derived from the gist description
+(or the gist ID when blank).`,
 		Args: cobra.RangeArgs(1, gist.MaxCloneArgs()),
 		RunE: func(_ *cobra.Command, args []string) error {
 			sshAlias := args[0]

--- a/internal/gist/clone.go
+++ b/internal/gist/clone.go
@@ -90,11 +90,14 @@ func RunClone(cfg CloneConfig) error {
 }
 
 // ComputeDiff computes which remote gists are missing locally and which local
-// directories are not present on the remote.
+// directories are not present on the remote. Keys are assigned via AssignKeys
+// so two gists with colliding slugs each get a unique on-disk path.
 func ComputeDiff(remote []Gist, local []string) ([]Gist, []string) {
+	keys := AssignKeys(remote)
+
 	remoteSet := make(map[string]Gist, len(remote))
 	for _, g := range remote {
-		remoteSet[Key(g)] = g
+		remoteSet[keys[g.ID]] = g
 	}
 
 	localSet := make(map[string]struct{}, len(local))
@@ -127,12 +130,15 @@ func CloneMissing(missing []Gist, cfg CloneConfig) (int, int) {
 		return 0, 0
 	}
 
+	keys := AssignKeys(missing)
+
 	if cfg.DryRun {
 		for _, g := range missing {
 			url := SSHCloneURL(g, cfg.SSHAlias)
-			target := filepath.Join(cfg.RootDir, Key(g))
+			key := keys[g.ID]
+			target := filepath.Join(cfg.RootDir, key)
 			log.WithFields(logger.Fields{
-				"gist":   Key(g),
+				"gist":   key,
 				"url":    url,
 				"target": target,
 			}).Info("would clone gist")
@@ -149,13 +155,14 @@ func CloneMissing(missing []Gist, cfg CloneConfig) (int, int) {
 		return 0, len(missing)
 	}
 
-	return ParallelClone(missing, cfg.SSHAlias, cfg.RootDir, cfg.Runner, log)
+	return parallelCloneWithKeys(missing, keys, cfg.SSHAlias, cfg.RootDir, cfg.Runner, log)
 }
 
-// SSHPreflight verifies SSH access to gist.github.com via the same mechanism
-// used for repository cloning.
+// SSHPreflight verifies SSH access to gist.github.com via the SSH config alias.
+// It must check gist.github.com (not github.com) because gists are served from
+// a separate SSH host that may have its own SSH config alias.
 func SSHPreflight(sshAlias string, log logger.FieldLogger) error {
-	return repo.SSHPreflight("github", sshAlias, log)
+	return repo.SSHPreflightHost(gistHost, sshAlias, log)
 }
 
 type cloneResult struct {
@@ -166,6 +173,16 @@ type cloneResult struct {
 // ParallelClone clones the given gists concurrently using a worker pool.
 func ParallelClone(
 	gists []Gist, sshAlias, rootDir string, runner repo.GitRunner, log logger.FieldLogger,
+) (int, int) {
+	return parallelCloneWithKeys(gists, AssignKeys(gists), sshAlias, rootDir, runner, log)
+}
+
+func parallelCloneWithKeys(
+	gists []Gist,
+	keys map[string]string,
+	sshAlias, rootDir string,
+	runner repo.GitRunner,
+	log logger.FieldLogger,
 ) (int, int) {
 	workers := runtime.NumCPU()
 	sem := make(chan struct{}, workers)
@@ -180,10 +197,10 @@ func ParallelClone(
 	for i, g := range gists {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, gist Gist) {
+		go func(idx int, g Gist) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[idx] = cloneSingle(gist, sshAlias, rootDir, runner, log)
+			results[idx] = cloneSingle(g, keys[g.ID], sshAlias, rootDir, runner, log)
 		}(i, g)
 	}
 	wg.Wait()
@@ -204,11 +221,10 @@ func ParallelClone(
 }
 
 func cloneSingle(
-	g Gist, sshAlias, rootDir string, runner repo.GitRunner, log logger.FieldLogger,
+	g Gist, key, sshAlias, rootDir string, runner repo.GitRunner, log logger.FieldLogger,
 ) cloneResult {
 	url := SSHCloneURL(g, sshAlias)
-	target := filepath.Join(rootDir, Key(g))
-	key := Key(g)
+	target := filepath.Join(rootDir, key)
 
 	log.WithFields(logger.Fields{
 		"gist":   key,

--- a/internal/gist/clone.go
+++ b/internal/gist/clone.go
@@ -1,0 +1,228 @@
+package gist
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/rios0rios0/devforge/internal/repo"
+	logger "github.com/sirupsen/logrus"
+)
+
+const maxCloneArgs = 2
+
+// MaxCloneArgs returns the maximum positional arg count for the clone command.
+func MaxCloneArgs() int {
+	return maxCloneArgs
+}
+
+// PreflightFunc verifies SSH connectivity before cloning.
+type PreflightFunc func(sshAlias string, log logger.FieldLogger) error
+
+// CloneConfig wires dependencies for the gist clone workflow.
+type CloneConfig struct {
+	RootDir   string
+	Owner     string
+	SSHAlias  string
+	DryRun    bool
+	Provider  Provider
+	Runner    repo.GitRunner
+	Output    io.Writer
+	Logger    logger.FieldLogger
+	Preflight PreflightFunc
+}
+
+func (c *CloneConfig) log() logger.FieldLogger {
+	if c.Logger == nil {
+		c.Logger = repo.NewLogger(c.Output)
+	}
+	return c.Logger
+}
+
+// RunClone discovers gists for the owner and clones the missing ones.
+func RunClone(cfg CloneConfig) error {
+	log := cfg.log()
+
+	if cfg.Owner == "" {
+		return fmt.Errorf("owner must be provided to clone gists")
+	}
+
+	log.WithField("owner", cfg.Owner).Info("gist clone workflow started")
+	if cfg.DryRun {
+		log.Info("dry-run mode enabled")
+	}
+
+	remote, err := cfg.Provider.ListGists(context.Background(), cfg.Owner)
+	if err != nil {
+		return fmt.Errorf("failed to discover gists: %w", err)
+	}
+	log.WithField("count", len(remote)).Info("remote gists discovered")
+
+	local := ScanLocalGists(cfg.RootDir)
+	log.WithField("count", len(local)).Info("scanned local gists")
+
+	missing, extra := ComputeDiff(remote, local)
+	log.WithFields(logger.Fields{
+		"missing": len(missing),
+		"extra":   len(extra),
+	}).Info("computed gist diff")
+
+	if len(missing) == 0 && len(extra) == 0 {
+		log.Info("everything is in sync")
+		return nil
+	}
+
+	cloned, failed := CloneMissing(missing, cfg)
+	for _, name := range extra {
+		log.WithField("gist", name).Warn("extra local gist (not on remote)")
+	}
+
+	log.WithFields(logger.Fields{
+		"cloned": cloned,
+		"failed": failed,
+		"extra":  len(extra),
+	}).Info("gist clone workflow completed")
+	return nil
+}
+
+// ComputeDiff computes which remote gists are missing locally and which local
+// directories are not present on the remote.
+func ComputeDiff(remote []Gist, local []string) ([]Gist, []string) {
+	remoteSet := make(map[string]Gist, len(remote))
+	for _, g := range remote {
+		remoteSet[Key(g)] = g
+	}
+
+	localSet := make(map[string]struct{}, len(local))
+	for _, name := range local {
+		localSet[name] = struct{}{}
+	}
+
+	var missing []Gist
+	for key, g := range remoteSet {
+		if _, ok := localSet[key]; !ok {
+			missing = append(missing, g)
+		}
+	}
+
+	var extra []string
+	for _, name := range local {
+		if _, ok := remoteSet[name]; !ok {
+			extra = append(extra, name)
+		}
+	}
+
+	return missing, extra
+}
+
+// CloneMissing clones the missing gists, honouring dry-run mode.
+func CloneMissing(missing []Gist, cfg CloneConfig) (int, int) {
+	log := cfg.log()
+
+	if len(missing) == 0 {
+		return 0, 0
+	}
+
+	if cfg.DryRun {
+		for _, g := range missing {
+			url := SSHCloneURL(g, cfg.SSHAlias)
+			target := filepath.Join(cfg.RootDir, Key(g))
+			log.WithFields(logger.Fields{
+				"gist":   Key(g),
+				"url":    url,
+				"target": target,
+			}).Info("would clone gist")
+		}
+		return 0, 0
+	}
+
+	preflight := cfg.Preflight
+	if preflight == nil {
+		preflight = SSHPreflight
+	}
+	if preflightErr := preflight(cfg.SSHAlias, log); preflightErr != nil {
+		log.WithError(preflightErr).Error("SSH preflight failed")
+		return 0, len(missing)
+	}
+
+	return ParallelClone(missing, cfg.SSHAlias, cfg.RootDir, cfg.Runner, log)
+}
+
+// SSHPreflight verifies SSH access to gist.github.com via the same mechanism
+// used for repository cloning.
+func SSHPreflight(sshAlias string, log logger.FieldLogger) error {
+	return repo.SSHPreflight("github", sshAlias, log)
+}
+
+type cloneResult struct {
+	name    string
+	success bool
+}
+
+// ParallelClone clones the given gists concurrently using a worker pool.
+func ParallelClone(
+	gists []Gist, sshAlias, rootDir string, runner repo.GitRunner, log logger.FieldLogger,
+) (int, int) {
+	workers := runtime.NumCPU()
+	sem := make(chan struct{}, workers)
+	results := make([]cloneResult, len(gists))
+	var wg sync.WaitGroup
+
+	log.WithFields(logger.Fields{
+		"count":   len(gists),
+		"workers": workers,
+	}).Info("starting parallel gist clone")
+
+	for i, g := range gists {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, gist Gist) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[idx] = cloneSingle(gist, sshAlias, rootDir, runner, log)
+		}(i, g)
+	}
+	wg.Wait()
+
+	cloned, failed := 0, 0
+	for _, r := range results {
+		if r.success {
+			cloned++
+		} else {
+			failed++
+		}
+	}
+	log.WithFields(logger.Fields{
+		"cloned": cloned,
+		"failed": failed,
+	}).Info("parallel gist clone completed")
+	return cloned, failed
+}
+
+func cloneSingle(
+	g Gist, sshAlias, rootDir string, runner repo.GitRunner, log logger.FieldLogger,
+) cloneResult {
+	url := SSHCloneURL(g, sshAlias)
+	target := filepath.Join(rootDir, Key(g))
+	key := Key(g)
+
+	log.WithFields(logger.Fields{
+		"gist":   key,
+		"url":    url,
+		"target": target,
+	}).Info("cloning gist")
+
+	if err := runner.Clone(url, target); err != nil {
+		log.WithField("gist", key).WithError(err).Error("clone failed")
+		return cloneResult{name: key}
+	}
+
+	log.WithFields(logger.Fields{
+		"gist":   key,
+		"target": target,
+	}).Info("gist cloned")
+	return cloneResult{name: key, success: true}
+}

--- a/internal/gist/clone.go
+++ b/internal/gist/clone.go
@@ -2,6 +2,7 @@ package gist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -47,7 +48,7 @@ func RunClone(cfg CloneConfig) error {
 	log := cfg.log()
 
 	if cfg.Owner == "" {
-		return fmt.Errorf("owner must be provided to clone gists")
+		return errors.New("owner must be provided to clone gists")
 	}
 
 	log.WithField("owner", cfg.Owner).Info("gist clone workflow started")

--- a/internal/gist/clone_test.go
+++ b/internal/gist/clone_test.go
@@ -1,0 +1,328 @@
+package gist_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	logger "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/devforge/internal/gist"
+	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+)
+
+func TestComputeDiff(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return missing entries for remote gists not present locally", func(t *testing.T) {
+		t.Parallel()
+		// given
+		remote := []gist.Gist{
+			{ID: "1", Owner: "alice", Description: "First"},
+			{ID: "2", Owner: "alice", Description: "Second"},
+		}
+		local := []string{"alice/first"}
+
+		// when
+		missing, extra := gist.ComputeDiff(remote, local)
+
+		// then
+		require.Len(t, missing, 1)
+		assert.Equal(t, "2", missing[0].ID)
+		assert.Empty(t, extra)
+	})
+
+	t.Run("should return extras for local gists not present on remote", func(t *testing.T) {
+		t.Parallel()
+		// given
+		remote := []gist.Gist{{ID: "1", Owner: "alice", Description: "First"}}
+		local := []string{"alice/first", "alice/orphan"}
+
+		// when
+		missing, extra := gist.ComputeDiff(remote, local)
+
+		// then
+		assert.Empty(t, missing)
+		assert.Equal(t, []string{"alice/orphan"}, extra)
+	})
+
+	t.Run("should report nothing when remote and local match", func(t *testing.T) {
+		t.Parallel()
+		// given
+		remote := []gist.Gist{{ID: "1", Owner: "alice", Description: "Same"}}
+		local := []string{"alice/same"}
+
+		// when
+		missing, extra := gist.ComputeDiff(remote, local)
+
+		// then
+		assert.Empty(t, missing)
+		assert.Empty(t, extra)
+	})
+}
+
+func TestCloneMissing(t *testing.T) {
+	t.Parallel()
+
+	noopPreflight := func(_ string, _ logger.FieldLogger) error { return nil }
+
+	t.Run("should return zero counts when nothing is missing", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		cfg := gist.CloneConfig{
+			RootDir: "/tmp/gists",
+			Output:  &buf,
+			Logger:  repo.NewLogger(&buf),
+		}
+
+		// when
+		cloned, failed := gist.CloneMissing(nil, cfg)
+
+		// then
+		assert.Equal(t, 0, cloned)
+		assert.Equal(t, 0, failed)
+	})
+
+	t.Run("should clone every gist when preflight succeeds", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		cfg := gist.CloneConfig{
+			RootDir:   "/tmp/gists",
+			SSHAlias:  "mine",
+			Runner:    doubles.NewGitRunnerStub(),
+			Output:    &buf,
+			Logger:    repo.NewLogger(&buf),
+			Preflight: noopPreflight,
+		}
+		missing := []gist.Gist{
+			{ID: "1", Owner: "alice", Description: "First"},
+			{ID: "2", Owner: "alice", Description: "Second"},
+		}
+
+		// when
+		cloned, failed := gist.CloneMissing(missing, cfg)
+
+		// then
+		assert.Equal(t, 2, cloned)
+		assert.Equal(t, 0, failed)
+		assert.Contains(t, buf.String(), "gist cloned")
+	})
+
+	t.Run("should mark every gist as failed when preflight fails", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		failPreflight := func(_ string, _ logger.FieldLogger) error { return errors.New("ssh failed") }
+		cfg := gist.CloneConfig{
+			RootDir:   "/tmp/gists",
+			SSHAlias:  "mine",
+			Output:    &buf,
+			Logger:    repo.NewLogger(&buf),
+			Preflight: failPreflight,
+		}
+		missing := []gist.Gist{
+			{ID: "1", Owner: "alice"},
+			{ID: "2", Owner: "alice"},
+		}
+
+		// when
+		cloned, failed := gist.CloneMissing(missing, cfg)
+
+		// then
+		assert.Equal(t, 0, cloned)
+		assert.Equal(t, 2, failed)
+		assert.Contains(t, buf.String(), "SSH preflight failed")
+	})
+
+	t.Run("should log preview output without cloning in dry-run mode", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		cfg := gist.CloneConfig{
+			RootDir:  "/tmp/gists",
+			SSHAlias: "mine",
+			DryRun:   true,
+			Output:   &buf,
+			Logger:   repo.NewLogger(&buf),
+		}
+		missing := []gist.Gist{{ID: "1", Owner: "alice", Description: "Snippet"}}
+
+		// when
+		cloned, failed := gist.CloneMissing(missing, cfg)
+
+		// then
+		assert.Equal(t, 0, cloned)
+		assert.Equal(t, 0, failed)
+		assert.Contains(t, buf.String(), "would clone gist")
+	})
+}
+
+func TestRunClone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should report sync when remote and local are aligned", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		root := t.TempDir()
+		createGistRepo(t, root+"/alice/snippet")
+		provider := doubles.NewGistProviderStub().WithGists([]gist.Gist{
+			{ID: "abc", Owner: "alice", Description: "Snippet"},
+		})
+		cfg := gist.CloneConfig{
+			RootDir:  root,
+			Owner:    "alice",
+			SSHAlias: "mine",
+			Provider: provider,
+			Runner:   doubles.NewGitRunnerStub(),
+			Output:   &buf,
+			Logger:   repo.NewLogger(&buf),
+		}
+
+		// when
+		err := gist.RunClone(cfg)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "everything is in sync")
+	})
+
+	t.Run("should return an error when the provider call fails", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		provider := doubles.NewGistProviderStub().WithListError(errors.New("API error"))
+		cfg := gist.CloneConfig{
+			RootDir:  "/tmp/gists",
+			Owner:    "alice",
+			SSHAlias: "mine",
+			Provider: provider,
+			Output:   &buf,
+			Logger:   repo.NewLogger(&buf),
+		}
+
+		// when
+		err := gist.RunClone(cfg)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to discover gists")
+	})
+
+	t.Run("should return an error when the owner is missing", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		cfg := gist.CloneConfig{
+			RootDir: "/tmp/gists",
+			Output:  &buf,
+			Logger:  repo.NewLogger(&buf),
+		}
+
+		// when
+		err := gist.RunClone(cfg)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "owner")
+	})
+
+	t.Run("should preview missing gists in dry-run mode", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		root := t.TempDir()
+		provider := doubles.NewGistProviderStub().WithGists([]gist.Gist{
+			{ID: "abc", Owner: "alice", Description: "Brand New"},
+		})
+		cfg := gist.CloneConfig{
+			RootDir:  root,
+			Owner:    "alice",
+			SSHAlias: "mine",
+			DryRun:   true,
+			Provider: provider,
+			Output:   &buf,
+			Logger:   repo.NewLogger(&buf),
+		}
+
+		// when
+		err := gist.RunClone(cfg)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "would clone gist")
+	})
+}
+
+func TestParallelClone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should clone every gist successfully", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		runner := doubles.NewGitRunnerStub()
+		gists := []gist.Gist{
+			{ID: "1", Owner: "alice", Description: "First"},
+			{ID: "2", Owner: "alice", Description: "Second"},
+		}
+
+		// when
+		cloned, failed := gist.ParallelClone(gists, "mine", "/tmp/gists", runner, repo.NewLogger(&buf))
+
+		// then
+		assert.Equal(t, 2, cloned)
+		assert.Equal(t, 0, failed)
+	})
+
+	t.Run("should count failures when the runner returns an error", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		runner := doubles.NewGitRunnerStub().WithCloneError(errors.New("permission denied"))
+		gists := []gist.Gist{
+			{ID: "1", Owner: "alice", Description: "First"},
+			{ID: "2", Owner: "alice", Description: "Second"},
+		}
+
+		// when
+		cloned, failed := gist.ParallelClone(gists, "mine", "/tmp/gists", runner, repo.NewLogger(&buf))
+
+		// then
+		assert.Equal(t, 0, cloned)
+		assert.Equal(t, 2, failed)
+		assert.Contains(t, buf.String(), "clone failed")
+	})
+
+	t.Run("should be safe with an empty input", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		runner := doubles.NewGitRunnerStub()
+
+		// when
+		cloned, failed := gist.ParallelClone(nil, "mine", "/tmp/gists", runner, repo.NewLogger(&buf))
+
+		// then
+		assert.Equal(t, 0, cloned)
+		assert.Equal(t, 0, failed)
+	})
+}
+
+func TestMaxCloneArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return 2", func(t *testing.T) {
+		t.Parallel()
+		// given / when
+		result := gist.MaxCloneArgs()
+
+		// then
+		assert.Equal(t, 2, result)
+	})
+}

--- a/internal/gist/clone_test.go
+++ b/internal/gist/clone_test.go
@@ -24,7 +24,7 @@ func TestComputeDiff(t *testing.T) {
 			{ID: "1", Owner: "alice", Description: "First"},
 			{ID: "2", Owner: "alice", Description: "Second"},
 		}
-		local := []string{"alice/first"}
+		local := []string{"first"}
 
 		// when
 		missing, extra := gist.ComputeDiff(remote, local)
@@ -39,27 +39,45 @@ func TestComputeDiff(t *testing.T) {
 		t.Parallel()
 		// given
 		remote := []gist.Gist{{ID: "1", Owner: "alice", Description: "First"}}
-		local := []string{"alice/first", "alice/orphan"}
+		local := []string{"first", "orphan"}
 
 		// when
 		missing, extra := gist.ComputeDiff(remote, local)
 
 		// then
 		assert.Empty(t, missing)
-		assert.Equal(t, []string{"alice/orphan"}, extra)
+		assert.Equal(t, []string{"orphan"}, extra)
 	})
 
 	t.Run("should report nothing when remote and local match", func(t *testing.T) {
 		t.Parallel()
 		// given
 		remote := []gist.Gist{{ID: "1", Owner: "alice", Description: "Same"}}
-		local := []string{"alice/same"}
+		local := []string{"same"}
 
 		// when
 		missing, extra := gist.ComputeDiff(remote, local)
 
 		// then
 		assert.Empty(t, missing)
+		assert.Empty(t, extra)
+	})
+
+	t.Run("should disambiguate colliding slugs and not drop entries", func(t *testing.T) {
+		t.Parallel()
+		// given two remote gists with the same description (and so the same
+		// natural slug) — both must appear as missing instead of one
+		// overwriting the other in the remote map.
+		remote := []gist.Gist{
+			{ID: "aaaaaaa1", Owner: "alice", Description: "Duplicate"},
+			{ID: "bbbbbbb2", Owner: "alice", Description: "Duplicate"},
+		}
+
+		// when
+		missing, extra := gist.ComputeDiff(remote, nil)
+
+		// then
+		assert.Len(t, missing, 2)
 		assert.Empty(t, extra)
 	})
 }
@@ -170,7 +188,7 @@ func TestRunClone(t *testing.T) {
 		// given
 		var buf bytes.Buffer
 		root := t.TempDir()
-		createGistRepo(t, root+"/alice/snippet")
+		createGistRepo(t, root+"/snippet")
 		provider := doubles.NewGistProviderStub().WithGists([]gist.Gist{
 			{ID: "abc", Owner: "alice", Description: "Snippet"},
 		})

--- a/internal/gist/gist.go
+++ b/internal/gist/gist.go
@@ -1,0 +1,95 @@
+package gist
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	gistHost      = "gist.github.com"
+	maxSlugLength = 60
+)
+
+// Gist represents a single GitHub gist used for clone/sync orchestration.
+type Gist struct {
+	ID          string
+	Owner       string
+	Description string
+}
+
+// Key returns the local directory key for a gist: "<owner>/<slug>".
+func Key(g Gist) string {
+	return g.Owner + "/" + Slug(g)
+}
+
+// Slug derives a URL/path-safe slug from the gist description, falling back
+// to the gist ID when no description is present or the description sanitizes
+// to an empty string.
+func Slug(g Gist) string {
+	if s := slugify(g.Description); s != "" {
+		return s
+	}
+	return g.ID
+}
+
+//nolint:gochecknoglobals // compiled-once regex used for slug sanitization
+var slugSeparators = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify converts a free-form description into a kebab-case slug.
+// It uses the first non-empty line as the summary, lowercases it, replaces
+// any run of non-alphanumeric characters with a single hyphen, trims hyphens
+// from both ends, and truncates to maxSlugLength characters.
+func slugify(description string) string {
+	summary := firstNonEmptyLine(description)
+	if summary == "" {
+		return ""
+	}
+	lowered := strings.ToLower(summary)
+	replaced := slugSeparators.ReplaceAllString(lowered, "-")
+	trimmed := strings.Trim(replaced, "-")
+	if len(trimmed) > maxSlugLength {
+		trimmed = strings.TrimRight(trimmed[:maxSlugLength], "-")
+	}
+	return trimmed
+}
+
+func firstNonEmptyLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// SSHCloneURL builds the SSH clone URL for a gist, optionally appending an
+// SSH config alias suffix to the host (matching the repo command convention).
+func SSHCloneURL(g Gist, alias string) string {
+	host := gistHost
+	if alias != "" {
+		host = fmt.Sprintf("%s-%s", host, alias)
+	}
+	return fmt.Sprintf("git@%s:%s.git", host, g.ID)
+}
+
+// Host returns the canonical gist host name.
+func Host() string {
+	return gistHost
+}
+
+// DetectOwner extracts the gist owner from a path containing
+// ".../gist.github.com/<owner>" (with or without a trailing slug).
+func DetectOwner(rootDir string) (string, error) {
+	const segment = "/" + gistHost + "/"
+	idx := strings.Index(rootDir, segment)
+	if idx < 0 {
+		return "", fmt.Errorf("could not detect gist owner from path: %s", rootDir)
+	}
+	after := rootDir[idx+len(segment):]
+	parts := strings.SplitN(after, "/", 2)
+	if parts[0] == "" {
+		return "", fmt.Errorf("could not extract owner from path: %s", rootDir)
+	}
+	return parts[0], nil
+}

--- a/internal/gist/gist.go
+++ b/internal/gist/gist.go
@@ -33,7 +33,6 @@ func Slug(g Gist) string {
 	return g.ID
 }
 
-//nolint:gochecknoglobals // compiled-once regex used for slug sanitization
 var slugSeparators = regexp.MustCompile(`[^a-z0-9]+`)
 
 // slugify converts a free-form description into a kebab-case slug.
@@ -55,7 +54,7 @@ func slugify(description string) string {
 }
 
 func firstNonEmptyLine(text string) string {
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		if t := strings.TrimSpace(line); t != "" {
 			return t
 		}
@@ -82,14 +81,13 @@ func Host() string {
 // ".../gist.github.com/<owner>" (with or without a trailing slug).
 func DetectOwner(rootDir string) (string, error) {
 	const segment = "/" + gistHost + "/"
-	idx := strings.Index(rootDir, segment)
-	if idx < 0 {
+	_, after, found := strings.Cut(rootDir, segment)
+	if !found {
 		return "", fmt.Errorf("could not detect gist owner from path: %s", rootDir)
 	}
-	after := rootDir[idx+len(segment):]
-	parts := strings.SplitN(after, "/", 2)
-	if parts[0] == "" {
+	owner, _, _ := strings.Cut(after, "/")
+	if owner == "" {
 		return "", fmt.Errorf("could not extract owner from path: %s", rootDir)
 	}
-	return parts[0], nil
+	return owner, nil
 }

--- a/internal/gist/gist.go
+++ b/internal/gist/gist.go
@@ -18,9 +18,12 @@ type Gist struct {
 	Description string
 }
 
-// Key returns the local directory key for a gist: "<owner>/<slug>".
+// Key returns the natural on-disk key for a gist (just the slug). The owner
+// is implied by the root directory the command is operating on, so it is not
+// repeated in the key. When two gists share the same slug, callers should use
+// AssignKeys to disambiguate them.
 func Key(g Gist) string {
-	return g.Owner + "/" + Slug(g)
+	return Slug(g)
 }
 
 // Slug derives a URL/path-safe slug from the gist description, falling back
@@ -31,6 +34,32 @@ func Slug(g Gist) string {
 		return s
 	}
 	return g.ID
+}
+
+// AssignKeys returns a deterministic mapping from gist ID to a unique on-disk
+// key. Most gists keep their natural slug. When two or more gists share the
+// same slug (e.g., identical first-line descriptions), each colliding entry
+// gets a "<slug>-<short-id>" suffix to keep the path unique.
+func AssignKeys(gists []Gist) map[string]string {
+	const shortIDLen = 7
+	counts := make(map[string]int, len(gists))
+	for _, g := range gists {
+		counts[Slug(g)]++
+	}
+	keys := make(map[string]string, len(gists))
+	for _, g := range gists {
+		slug := Slug(g)
+		if counts[slug] > 1 {
+			id := g.ID
+			if len(id) > shortIDLen {
+				id = id[:shortIDLen]
+			}
+			keys[g.ID] = slug + "-" + id
+		} else {
+			keys[g.ID] = slug
+		}
+	}
+	return keys
 }
 
 var slugSeparators = regexp.MustCompile(`[^a-z0-9]+`)

--- a/internal/gist/gist_test.go
+++ b/internal/gist/gist_test.go
@@ -83,7 +83,7 @@ func TestSlug(t *testing.T) {
 
 		// then
 		assert.LessOrEqual(t, len(slug), 60)
-		assert.False(t, slug[len(slug)-1] == '-', "should not end with a hyphen")
+		assert.NotEqual(t, byte('-'), slug[len(slug)-1], "should not end with a hyphen")
 	})
 }
 

--- a/internal/gist/gist_test.go
+++ b/internal/gist/gist_test.go
@@ -90,7 +90,7 @@ func TestSlug(t *testing.T) {
 func TestKey(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should join the owner and slug with a slash", func(t *testing.T) {
+	t.Run("should return the slug derived from the description", func(t *testing.T) {
 		t.Parallel()
 		// given
 		g := gist.Gist{ID: "abc", Owner: "alice", Description: "Snippet"}
@@ -99,7 +99,7 @@ func TestKey(t *testing.T) {
 		key := gist.Key(g)
 
 		// then
-		assert.Equal(t, "alice/snippet", key)
+		assert.Equal(t, "snippet", key)
 	})
 
 	t.Run("should fall back to the ID when there is no description", func(t *testing.T) {
@@ -111,7 +111,59 @@ func TestKey(t *testing.T) {
 		key := gist.Key(g)
 
 		// then
-		assert.Equal(t, "alice/abc", key)
+		assert.Equal(t, "abc", key)
+	})
+}
+
+func TestAssignKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should keep natural slugs when there are no collisions", func(t *testing.T) {
+		t.Parallel()
+		// given
+		gists := []gist.Gist{
+			{ID: "1", Description: "First"},
+			{ID: "2", Description: "Second"},
+		}
+
+		// when
+		keys := gist.AssignKeys(gists)
+
+		// then
+		assert.Equal(t, "first", keys["1"])
+		assert.Equal(t, "second", keys["2"])
+	})
+
+	t.Run("should disambiguate duplicate slugs with a short ID suffix", func(t *testing.T) {
+		t.Parallel()
+		// given
+		gists := []gist.Gist{
+			{ID: "1234567abcdef", Description: "Same Title"},
+			{ID: "abcdef1234567", Description: "Same Title"},
+		}
+
+		// when
+		keys := gist.AssignKeys(gists)
+
+		// then
+		assert.Equal(t, "same-title-1234567", keys["1234567abcdef"])
+		assert.Equal(t, "same-title-abcdef1", keys["abcdef1234567"])
+	})
+
+	t.Run("should pad short IDs without panicking", func(t *testing.T) {
+		t.Parallel()
+		// given
+		gists := []gist.Gist{
+			{ID: "ab", Description: "Same"},
+			{ID: "cd", Description: "Same"},
+		}
+
+		// when
+		keys := gist.AssignKeys(gists)
+
+		// then
+		assert.Equal(t, "same-ab", keys["ab"])
+		assert.Equal(t, "same-cd", keys["cd"])
 	})
 }
 

--- a/internal/gist/gist_test.go
+++ b/internal/gist/gist_test.go
@@ -1,0 +1,187 @@
+package gist_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/devforge/internal/gist"
+)
+
+func TestSlug(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should derive slug from a single-line description", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc123", Description: "My Cool Snippet"}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.Equal(t, "my-cool-snippet", slug)
+	})
+
+	t.Run("should fall back to gist ID when description is empty", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc123", Description: ""}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.Equal(t, "abc123", slug)
+	})
+
+	t.Run("should fall back to gist ID when description sanitizes to empty", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc123", Description: "***"}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.Equal(t, "abc123", slug)
+	})
+
+	t.Run("should use only the first non-empty line as a summary", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "id", Description: "\n\nFirst summary line\nSecond line that should be ignored"}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.Equal(t, "first-summary-line", slug)
+	})
+
+	t.Run("should collapse runs of non-alphanumeric characters into single hyphens", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "id", Description: "Hello, World!! -- 123"}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.Equal(t, "hello-world-123", slug)
+	})
+
+	t.Run("should truncate slugs longer than the maximum length", func(t *testing.T) {
+		t.Parallel()
+		// given
+		long := "a-very-long-description-that-easily-exceeds-the-sixty-character-cap-for-slugs"
+		g := gist.Gist{ID: "id", Description: long}
+
+		// when
+		slug := gist.Slug(g)
+
+		// then
+		assert.LessOrEqual(t, len(slug), 60)
+		assert.False(t, slug[len(slug)-1] == '-', "should not end with a hyphen")
+	})
+}
+
+func TestKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should join the owner and slug with a slash", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc", Owner: "alice", Description: "Snippet"}
+
+		// when
+		key := gist.Key(g)
+
+		// then
+		assert.Equal(t, "alice/snippet", key)
+	})
+
+	t.Run("should fall back to the ID when there is no description", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc", Owner: "alice"}
+
+		// when
+		key := gist.Key(g)
+
+		// then
+		assert.Equal(t, "alice/abc", key)
+	})
+}
+
+func TestSSHCloneURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should build SSH URL without an alias", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc"}
+
+		// when
+		url := gist.SSHCloneURL(g, "")
+
+		// then
+		assert.Equal(t, "git@gist.github.com:abc.git", url)
+	})
+
+	t.Run("should append the alias suffix to the host", func(t *testing.T) {
+		t.Parallel()
+		// given
+		g := gist.Gist{ID: "abc"}
+
+		// when
+		url := gist.SSHCloneURL(g, "mine")
+
+		// then
+		assert.Equal(t, "git@gist.github.com-mine:abc.git", url)
+	})
+}
+
+func TestDetectOwner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract owner from a path containing gist.github.com/<owner>", func(t *testing.T) {
+		t.Parallel()
+		// given
+		path := "/home/user/Development/gist.github.com/alice"
+
+		// when
+		owner, err := gist.DetectOwner(path)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "alice", owner)
+	})
+
+	t.Run("should ignore trailing path segments below the owner", func(t *testing.T) {
+		t.Parallel()
+		// given
+		path := "/dev/gist.github.com/bob/some-gist"
+
+		// when
+		owner, err := gist.DetectOwner(path)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "bob", owner)
+	})
+
+	t.Run("should return an error when the path does not contain gist.github.com", func(t *testing.T) {
+		t.Parallel()
+		// given
+		path := "/home/user/Development/github.com/alice"
+
+		// when
+		_, err := gist.DetectOwner(path)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not detect")
+	})
+}

--- a/internal/gist/provider.go
+++ b/internal/gist/provider.go
@@ -2,6 +2,7 @@ package gist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -53,7 +54,7 @@ func (p *GitHubProvider) ListGists(ctx context.Context, owner string) ([]Gist, e
 func ResolveProvider() (Provider, error) {
 	token := os.Getenv("GH_TOKEN")
 	if token == "" {
-		return nil, fmt.Errorf("GH_TOKEN environment variable not set")
+		return nil, errors.New("GH_TOKEN environment variable not set")
 	}
 	return NewGitHubProvider(token), nil
 }

--- a/internal/gist/provider.go
+++ b/internal/gist/provider.go
@@ -1,0 +1,59 @@
+package gist
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	gh "github.com/google/go-github/v66/github"
+)
+
+// Provider lists gists for a given owner.
+type Provider interface {
+	ListGists(ctx context.Context, owner string) ([]Gist, error)
+}
+
+// GitHubProvider fetches gists from the GitHub REST API.
+type GitHubProvider struct {
+	client *gh.Client
+}
+
+// NewGitHubProvider builds a GitHub gist provider using a personal access token.
+func NewGitHubProvider(token string) *GitHubProvider {
+	return &GitHubProvider{client: gh.NewClient(nil).WithAuthToken(token)}
+}
+
+// ListGists paginates through all gists belonging to owner.
+func (p *GitHubProvider) ListGists(ctx context.Context, owner string) ([]Gist, error) {
+	const pageSize = 100
+	opts := &gh.GistListOptions{ListOptions: gh.ListOptions{PerPage: pageSize}}
+
+	var gists []Gist
+	for {
+		page, resp, err := p.client.Gists.List(ctx, owner, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list gists for %s: %w", owner, err)
+		}
+		for _, g := range page {
+			gists = append(gists, Gist{
+				ID:          g.GetID(),
+				Owner:       owner,
+				Description: g.GetDescription(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return gists, nil
+}
+
+// ResolveProvider builds a Provider, reading the GH_TOKEN environment variable.
+func ResolveProvider() (Provider, error) {
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("GH_TOKEN environment variable not set")
+	}
+	return NewGitHubProvider(token), nil
+}

--- a/internal/gist/scanner.go
+++ b/internal/gist/scanner.go
@@ -1,0 +1,41 @@
+package gist
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ScanLocalGists scans rootDir/<owner>/<slug> two levels deep for directories
+// containing a .git directory and returns "<owner>/<slug>" keys.
+func ScanLocalGists(rootDir string) []string {
+	var gists []string
+	owners, err := os.ReadDir(rootDir)
+	if err != nil {
+		return gists
+	}
+	for _, o := range owners {
+		if !o.IsDir() {
+			continue
+		}
+		gists = append(gists, scanOwnerGists(rootDir, o.Name())...)
+	}
+	return gists
+}
+
+func scanOwnerGists(rootDir, ownerName string) []string {
+	var gists []string
+	entries, err := os.ReadDir(filepath.Join(rootDir, ownerName))
+	if err != nil {
+		return gists
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		gitDir := filepath.Join(rootDir, ownerName, e.Name(), ".git")
+		if info, statErr := os.Stat(gitDir); statErr == nil && info.IsDir() {
+			gists = append(gists, ownerName+"/"+e.Name())
+		}
+	}
+	return gists
+}

--- a/internal/gist/scanner.go
+++ b/internal/gist/scanner.go
@@ -5,26 +5,12 @@ import (
 	"path/filepath"
 )
 
-// ScanLocalGists scans rootDir/<owner>/<slug> two levels deep for directories
-// containing a .git directory and returns "<owner>/<slug>" keys.
+// ScanLocalGists scans rootDir one level deep for directories containing a
+// .git directory and returns their basenames as keys. The owner is implied
+// by rootDir, so the keys match what Key (and AssignKeys) produce.
 func ScanLocalGists(rootDir string) []string {
 	var gists []string
-	owners, err := os.ReadDir(rootDir)
-	if err != nil {
-		return gists
-	}
-	for _, o := range owners {
-		if !o.IsDir() {
-			continue
-		}
-		gists = append(gists, scanOwnerGists(rootDir, o.Name())...)
-	}
-	return gists
-}
-
-func scanOwnerGists(rootDir, ownerName string) []string {
-	var gists []string
-	entries, err := os.ReadDir(filepath.Join(rootDir, ownerName))
+	entries, err := os.ReadDir(rootDir)
 	if err != nil {
 		return gists
 	}
@@ -32,9 +18,9 @@ func scanOwnerGists(rootDir, ownerName string) []string {
 		if !e.IsDir() {
 			continue
 		}
-		gitDir := filepath.Join(rootDir, ownerName, e.Name(), ".git")
+		gitDir := filepath.Join(rootDir, e.Name(), ".git")
 		if info, statErr := os.Stat(gitDir); statErr == nil && info.IsDir() {
-			gists = append(gists, ownerName+"/"+e.Name())
+			gists = append(gists, e.Name())
 		}
 	}
 	return gists

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -20,22 +20,22 @@ func createGistRepo(t *testing.T, path string) {
 func TestScanLocalGists(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should return owner/slug entries for nested gists", func(t *testing.T) {
+	t.Run("should return slug entries one level under the root", func(t *testing.T) {
 		t.Parallel()
 		// given
 		root := t.TempDir()
-		createGistRepo(t, filepath.Join(root, "alice", "snippet-one"))
-		createGistRepo(t, filepath.Join(root, "alice", "snippet-two"))
-		createGistRepo(t, filepath.Join(root, "bob", "config"))
+		createGistRepo(t, filepath.Join(root, "snippet-one"))
+		createGistRepo(t, filepath.Join(root, "snippet-two"))
+		createGistRepo(t, filepath.Join(root, "config"))
 
 		// when
 		gists := gist.ScanLocalGists(root)
 
 		// then
 		assert.ElementsMatch(t, []string{
-			"alice/snippet-one",
-			"alice/snippet-two",
-			"bob/config",
+			"snippet-one",
+			"snippet-two",
+			"config",
 		}, gists)
 	})
 
@@ -43,15 +43,15 @@ func TestScanLocalGists(t *testing.T) {
 		t.Parallel()
 		// given
 		root := t.TempDir()
-		createGistRepo(t, filepath.Join(root, "alice", "real-gist"))
-		err := os.MkdirAll(filepath.Join(root, "alice", "not-a-gist"), 0o750)
+		createGistRepo(t, filepath.Join(root, "real-gist"))
+		err := os.MkdirAll(filepath.Join(root, "not-a-gist"), 0o750)
 		require.NoError(t, err)
 
 		// when
 		gists := gist.ScanLocalGists(root)
 
 		// then
-		assert.Equal(t, []string{"alice/real-gist"}, gists)
+		assert.Equal(t, []string{"real-gist"}, gists)
 	})
 
 	t.Run("should return an empty slice when the root does not exist", func(t *testing.T) {

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rios0rios0/devforge/internal/gist"
 )
@@ -44,7 +45,7 @@ func TestScanLocalGists(t *testing.T) {
 		root := t.TempDir()
 		createGistRepo(t, filepath.Join(root, "alice", "real-gist"))
 		err := os.MkdirAll(filepath.Join(root, "alice", "not-a-gist"), 0o750)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// when
 		gists := gist.ScanLocalGists(root)

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -1,0 +1,67 @@
+package gist_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rios0rios0/devforge/internal/gist"
+)
+
+func createGistRepo(t *testing.T, path string) {
+	t.Helper()
+	err := os.MkdirAll(filepath.Join(path, ".git"), 0o750)
+	assert.NoError(t, err)
+}
+
+func TestScanLocalGists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return owner/slug entries for nested gists", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGistRepo(t, filepath.Join(root, "alice", "snippet-one"))
+		createGistRepo(t, filepath.Join(root, "alice", "snippet-two"))
+		createGistRepo(t, filepath.Join(root, "bob", "config"))
+
+		// when
+		gists := gist.ScanLocalGists(root)
+
+		// then
+		assert.ElementsMatch(t, []string{
+			"alice/snippet-one",
+			"alice/snippet-two",
+			"bob/config",
+		}, gists)
+	})
+
+	t.Run("should ignore directories without a .git child", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGistRepo(t, filepath.Join(root, "alice", "real-gist"))
+		err := os.MkdirAll(filepath.Join(root, "alice", "not-a-gist"), 0o750)
+		assert.NoError(t, err)
+
+		// when
+		gists := gist.ScanLocalGists(root)
+
+		// then
+		assert.Equal(t, []string{"alice/real-gist"}, gists)
+	})
+
+	t.Run("should return an empty slice when the root does not exist", func(t *testing.T) {
+		t.Parallel()
+		// given
+		nonExistent := filepath.Join(t.TempDir(), "missing")
+
+		// when
+		gists := gist.ScanLocalGists(nonExistent)
+
+		// then
+		assert.Empty(t, gists)
+	})
+}

--- a/internal/gist/sync.go
+++ b/internal/gist/sync.go
@@ -2,6 +2,7 @@ package gist
 
 import (
 	"io"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -12,11 +13,13 @@ import (
 
 // RunSync syncs all gists under rootDir in parallel, delegating per-gist work
 // to repo.SyncSingleRepo so it benefits from the same fetch/rebase/WIP logic.
+// Only the gist layout (rootDir/<slug>/.git) is scanned, so unrelated git
+// repositories nested deeper under rootDir are not synced.
 func RunSync(rootDir string, runner repo.GitRunner, output io.Writer) error {
 	log := repo.NewLogger(output)
 
-	gists := repo.FindAllRepos(rootDir)
-	total := len(gists)
+	slugs := ScanLocalGists(rootDir)
+	total := len(slugs)
 	if total == 0 {
 		log.WithField("dir", rootDir).Warn("no gist repositories found")
 		return nil
@@ -29,19 +32,20 @@ func RunSync(rootDir string, runner repo.GitRunner, output io.Writer) error {
 	results := make([]repo.SyncResult, total)
 	var wg sync.WaitGroup
 
-	for i, path := range gists {
+	for i, slug := range slugs {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, p string) {
+		go func(idx int, slug string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			result := repo.SyncSingleRepo(p, rootDir, runner)
+			path := filepath.Join(rootDir, slug)
+			result := repo.SyncSingleRepo(path, rootDir, runner)
 			log.WithFields(logger.Fields{
 				"gist":   result.Name,
 				"status": result.Status,
 			}).Info("sync result")
 			results[idx] = result
-		}(i, path)
+		}(i, slug)
 	}
 
 	wg.Wait()

--- a/internal/gist/sync.go
+++ b/internal/gist/sync.go
@@ -1,0 +1,68 @@
+package gist
+
+import (
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/rios0rios0/devforge/internal/repo"
+	logger "github.com/sirupsen/logrus"
+)
+
+// RunSync syncs all gists under rootDir in parallel, delegating per-gist work
+// to repo.SyncSingleRepo so it benefits from the same fetch/rebase/WIP logic.
+func RunSync(rootDir string, runner repo.GitRunner, output io.Writer) error {
+	log := repo.NewLogger(output)
+
+	gists := repo.FindAllRepos(rootDir)
+	total := len(gists)
+	if total == 0 {
+		log.WithField("dir", rootDir).Warn("no gist repositories found")
+		return nil
+	}
+
+	workers := runtime.NumCPU()
+	log.WithField("count", total).Info("found gists to sync")
+
+	sem := make(chan struct{}, workers)
+	results := make([]repo.SyncResult, total)
+	var wg sync.WaitGroup
+
+	for i, path := range gists {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, p string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			result := repo.SyncSingleRepo(p, rootDir, runner)
+			log.WithFields(logger.Fields{
+				"gist":   result.Name,
+				"status": result.Status,
+			}).Info("sync result")
+			results[idx] = result
+		}(i, path)
+	}
+
+	wg.Wait()
+
+	synced, wip, failed := 0, 0, 0
+	for _, r := range results {
+		switch {
+		case strings.HasPrefix(r.Status, "synced"):
+			synced++
+			if strings.Contains(r.Status, "wip") {
+				wip++
+			}
+		case strings.HasPrefix(r.Status, "FAIL"):
+			failed++
+		}
+	}
+
+	log.WithFields(logger.Fields{
+		"synced": synced,
+		"wip":    wip,
+		"failed": failed,
+	}).Info("summary")
+	return nil
+}

--- a/internal/gist/sync_test.go
+++ b/internal/gist/sync_test.go
@@ -33,8 +33,8 @@ func TestRunSync(t *testing.T) {
 		t.Parallel()
 		// given
 		root := t.TempDir()
-		createGistRepo(t, root+"/alice/snippet-one")
-		createGistRepo(t, root+"/alice/snippet-two")
+		createGistRepo(t, root+"/snippet-one")
+		createGistRepo(t, root+"/snippet-two")
 		runner := doubles.NewGitRunnerStub().
 			WithOutput(
 				[]string{"symbolic-ref", "refs/remotes/origin/HEAD"},

--- a/internal/gist/sync_test.go
+++ b/internal/gist/sync_test.go
@@ -1,0 +1,55 @@
+package gist_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/devforge/internal/gist"
+	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+)
+
+func TestRunSync(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should warn when no gists are found under the root", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		runner := doubles.NewGitRunnerStub()
+		var buf bytes.Buffer
+
+		// when
+		err := gist.RunSync(root, runner, &buf)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "no gist repositories found")
+	})
+
+	t.Run("should sync every nested gist and report a summary", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGistRepo(t, root+"/alice/snippet-one")
+		createGistRepo(t, root+"/alice/snippet-two")
+		runner := doubles.NewGitRunnerStub().
+			WithOutput(
+				[]string{"symbolic-ref", "refs/remotes/origin/HEAD"},
+				"refs/remotes/origin/main",
+			).
+			WithOutput([]string{"branch", "--show-current"}, "main").
+			WithOutput([]string{"status", "--porcelain"}, "")
+		var buf bytes.Buffer
+
+		// when
+		err := gist.RunSync(root, runner, &buf)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "summary")
+		assert.Contains(t, buf.String(), "synced")
+	})
+}

--- a/internal/repo/clone.go
+++ b/internal/repo/clone.go
@@ -213,7 +213,13 @@ func SSHPreflight(providerName, sshAlias string, log logger.FieldLogger) error {
 	if host == "" {
 		return fmt.Errorf("unknown provider for SSH preflight: %s", providerName)
 	}
+	return SSHPreflightHost(host, sshAlias, log)
+}
 
+// SSHPreflightHost verifies SSH connectivity to an explicit host via the SSH
+// config alias. Use this when the host is not registered in the provider
+// registry (e.g., gist.github.com).
+func SSHPreflightHost(host, sshAlias string, log logger.FieldLogger) error {
 	sshHost := host
 	if sshAlias != "" {
 		sshHost = fmt.Sprintf("%s-%s", host, sshAlias)

--- a/internal/testutil/doubles/gist_provider_stub.go
+++ b/internal/testutil/doubles/gist_provider_stub.go
@@ -8,9 +8,9 @@ import (
 
 // GistProviderStub is a configurable test double for gist.Provider.
 type GistProviderStub struct {
-	Gists    []gist.Gist
-	ListErr  error
-	LastUser string
+	Gists     []gist.Gist
+	ListErr   error
+	LastOwner string
 }
 
 // NewGistProviderStub creates a stub with no gists and no error.
@@ -29,7 +29,7 @@ func (s *GistProviderStub) WithListError(err error) *GistProviderStub {
 }
 
 func (s *GistProviderStub) ListGists(_ context.Context, owner string) ([]gist.Gist, error) {
-	s.LastUser = owner
+	s.LastOwner = owner
 	if s.ListErr != nil {
 		return nil, s.ListErr
 	}

--- a/internal/testutil/doubles/gist_provider_stub.go
+++ b/internal/testutil/doubles/gist_provider_stub.go
@@ -1,0 +1,37 @@
+package doubles
+
+import (
+	"context"
+
+	"github.com/rios0rios0/devforge/internal/gist"
+)
+
+// GistProviderStub is a configurable test double for gist.Provider.
+type GistProviderStub struct {
+	Gists    []gist.Gist
+	ListErr  error
+	LastUser string
+}
+
+// NewGistProviderStub creates a stub with no gists and no error.
+func NewGistProviderStub() *GistProviderStub {
+	return &GistProviderStub{}
+}
+
+func (s *GistProviderStub) WithGists(gs []gist.Gist) *GistProviderStub {
+	s.Gists = gs
+	return s
+}
+
+func (s *GistProviderStub) WithListError(err error) *GistProviderStub {
+	s.ListErr = err
+	return s
+}
+
+func (s *GistProviderStub) ListGists(_ context.Context, owner string) ([]gist.Gist, error) {
+	s.LastUser = owner
+	if s.ListErr != nil {
+		return nil, s.ListErr
+	}
+	return s.Gists, nil
+}


### PR DESCRIPTION
## Summary

- Adds `dev gist clone` and `dev gist sync` commands that mirror the existing repo workflow but target GitHub gists, organising them under `gist.github.com/<user>/<slug>`.
- The slug is derived from the gist description (first non-empty line, lowercased, kebab-cased, capped at 60 chars). When the description is blank or sanitises to empty, the gist ID is used instead.
- New `internal/gist` package: `Gist` entity, slug derivation, `Provider` interface with a `GitHubProvider` backed by `go-github`, scanner, and clone/sync orchestration.
- Reuses `repo.GitRunner`, `repo.SSHPreflight`, `repo.SyncSingleRepo`, and `repo.FindAllRepos` to avoid duplicating git plumbing.
- New `GistProviderStub` test double; BDD-style unit tests across `gist_test.go`, `scanner_test.go`, `clone_test.go`, and `sync_test.go` (84%+ coverage on the new package).
- README, CHANGELOG (`[Unreleased]`), and CLAUDE.md updated.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green; new package at 84.6% coverage)
- [x] `make build` produces `bin/dev`
- [x] `dev gist --help`, `dev gist clone --help`, `dev gist sync --help` render the expected usage
- [ ] End-to-end check against a real GitHub account (requires `GH_TOKEN`; not exercised in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)