### PR TITLE
chore(rename): rename devforge to dev-toolkit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
-# DevForge
+# Dev-Toolkit
 
-DevForge is a Go-based CLI tool (binary: `dev`) that manages Git repositories across multiple providers and bootstraps projects by detecting their language. It consolidates gitforge (Git hosting abstractions) and langforge (language detection) into a single workspace toolkit.
+Dev-Toolkit is a Go-based CLI tool (binary: `dev`) that manages Git repositories across multiple providers and bootstraps projects by detecting their language. It consolidates gitforge (Git hosting abstractions) and langforge (language detection) into a single workspace toolkit.
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
@@ -47,7 +47,7 @@ Always reference these instructions first and fallback to search or bash command
 ## Project Structure
 
 ### Key Files and Directories
-- `cmd/devforge/main.go` -- All CLI wiring (Cobra commands, dependency construction, update check)
+- `cmd/dev-toolkit/main.go` -- All CLI wiring (Cobra commands, dependency construction, update check)
 - `internal/repo/` -- Repository operations: clone, sync, fork-sync, prune, mirror, failover, restore
 - `internal/project/` -- Language-aware commands: start, build, lint, test, sast, stop, use, info
 - `internal/docker/` -- Docker management: container IPs, environment reset

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 # this space is for project generated files, DO NOT add personal or IDE files here
 # try to use ~/.gitignore of your user for your workspace generated files
 coverage.out
-devforge
+dev-toolkit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+- changed Go module path from `github.com/rios0rios0/devforge` to `github.com/rios0rios0/dev-toolkit` to align with the convention that reserves the `forge` suffix for libraries (`gitforge`, `langforge`, `cliforge`)
+- changed project name from `devforge` to `dev-toolkit` (binary remains `dev`)
+- changed `cmd/devforge/` directory to `cmd/dev-toolkit/`
+- changed install script environment variable prefix from `DEVFORGE_*` to `DEV_TOOLKIT_*`
 
 ## [0.8.0] - 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DevForge is a Go CLI tool (binary: `dev`) that manages Git repositories across multiple providers, provides language-aware project commands, and includes system housekeeping utilities. Built with Cobra (CLI), logrus (logging), gitforge (multi-provider Git operations), langforge (language detection), and cliforge (self-update).
+Dev-Toolkit is a Go CLI tool (binary: `dev`) that manages Git repositories across multiple providers, provides language-aware project commands, and includes system housekeeping utilities. Built with Cobra (CLI), logrus (logging), gitforge (multi-provider Git operations), langforge (language detection), and cliforge (self-update).
 
 ## Build and Development Commands
 
 ```bash
 make build          # Build binary to bin/dev (~1 second), always run after changes
-make run            # go run ./cmd/devforge (shows help)
+make run            # go run ./cmd/dev-toolkit (shows help)
 make debug          # Build with debug symbols (-N -l)
 make build-musl     # Fully static binary via musl-gcc (requires musl toolchain)
 make install        # Build and copy to ~/.local/bin/dev
@@ -59,7 +59,7 @@ dev version                                                     # print current 
 ## Architecture
 
 ```
-cmd/devforge/
+cmd/dev-toolkit/
   main.go                    -- all CLI wiring (Cobra commands, dependency construction, update check)
 internal/
   repo/

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,26 @@ SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 -include $(SCRIPTS_DIR)/makefiles/golang.mk
 
 VERSION ?= $(or $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//'),dev)
-LDFLAGS := -X main.version=$(VERSION) -X main.repoOwner=rios0rios0 -X main.repoName=devforge -X main.binaryName=dev
+LDFLAGS := -X main.version=$(VERSION) -X main.repoOwner=rios0rios0 -X main.repoName=dev-toolkit -X main.binaryName=dev
 
 .PHONY: debug build build-musl install run
 
 build:
 	rm -rf bin
-	go build -ldflags "$(LDFLAGS) -s -w" -o bin/dev ./cmd/devforge
+	go build -ldflags "$(LDFLAGS) -s -w" -o bin/dev ./cmd/dev-toolkit
 	strip -s bin/dev
 
 debug:
 	rm -rf bin
-	go build -gcflags "-N -l" -ldflags "$(LDFLAGS)" -o bin/dev ./cmd/devforge
+	go build -gcflags "-N -l" -ldflags "$(LDFLAGS)" -o bin/dev ./cmd/dev-toolkit
 
 build-musl:
 	CGO_ENABLED=1 CC=musl-gcc go build \
-		-ldflags '$(LDFLAGS) -linkmode external -extldflags="-static"' -o bin/dev ./cmd/devforge
+		-ldflags '$(LDFLAGS) -linkmode external -extldflags="-static"' -o bin/dev ./cmd/dev-toolkit
 	strip -s bin/dev
 
 run:
-	go run ./cmd/devforge
+	go run ./cmd/dev-toolkit
 
 install:
 	make build

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-<h1 align="center">DevForge</h1>
+<h1 align="center">Dev-Toolkit</h1>
 <p align="center">
-    <a href="https://github.com/rios0rios0/devforge/releases/latest">
-        <img src="https://img.shields.io/github/release/rios0rios0/devforge.svg?style=for-the-badge&logo=github" alt="Latest Release"/></a>
-    <a href="https://github.com/rios0rios0/devforge/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/rios0rios0/devforge.svg?style=for-the-badge&logo=github" alt="License"/></a>
-    <a href="https://github.com/rios0rios0/devforge/actions/workflows/default.yaml">
-        <img src="https://img.shields.io/github/actions/workflow/status/rios0rios0/devforge/default.yaml?branch=main&style=for-the-badge&logo=github" alt="Build Status"/></a>
+    <a href="https://github.com/rios0rios0/dev-toolkit/releases/latest">
+        <img src="https://img.shields.io/github/release/rios0rios0/dev-toolkit.svg?style=for-the-badge&logo=github" alt="Latest Release"/></a>
+    <a href="https://github.com/rios0rios0/dev-toolkit/blob/main/LICENSE">
+        <img src="https://img.shields.io/github/license/rios0rios0/dev-toolkit.svg?style=for-the-badge&logo=github" alt="License"/></a>
+    <a href="https://github.com/rios0rios0/dev-toolkit/actions/workflows/default.yaml">
+        <img src="https://img.shields.io/github/actions/workflow/status/rios0rios0/dev-toolkit/default.yaml?branch=main&style=for-the-badge&logo=github" alt="Build Status"/></a>
     <a href="https://www.bestpractices.dev/projects/12033">
         <img src="https://img.shields.io/cii/level/12033?style=for-the-badge&logo=opensourceinitiative" alt="OpenSSF Best Practices"/></a>
 </p>
 
-DevForge is a developer workspace toolkit that manages Git repositories across multiple providers and bootstraps projects by detecting their language. It consolidates [gitforge](https://github.com/rios0rios0/gitforge) and [langforge](https://github.com/rios0rios0/langforge) into a single CLI.
+Dev-Toolkit is a developer workspace toolkit that manages Git repositories across multiple providers and bootstraps projects by detecting their language. It consolidates [gitforge](https://github.com/rios0rios0/gitforge) and [langforge](https://github.com/rios0rios0/langforge) into a single CLI.
 
 ## Features
 
@@ -26,16 +26,16 @@ DevForge is a developer workspace toolkit that manages Git repositories across m
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh | sh
 ```
 
 Or build from source:
 
 ```bash
-go install github.com/rios0rios0/devforge/cmd/devforge@latest
+go install github.com/rios0rios0/dev-toolkit/cmd/dev-toolkit@latest
 ```
 
-Download pre-built binaries from the [releases page](https://github.com/rios0rios0/devforge/releases).
+Download pre-built binaries from the [releases page](https://github.com/rios0rios0/dev-toolkit/releases).
 
 ## Usage
 

--- a/cmd/dev-toolkit/main.go
+++ b/cmd/dev-toolkit/main.go
@@ -5,11 +5,11 @@ import (
 	"path/filepath"
 
 	"github.com/rios0rios0/cliforge/pkg/selfupdate"
-	"github.com/rios0rios0/devforge/internal/docker"
-	"github.com/rios0rios0/devforge/internal/gist"
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/system"
+	"github.com/rios0rios0/dev-toolkit/internal/docker"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/system"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ import (
 var (
 	version    = "dev"
 	repoOwner  = "rios0rios0"
-	repoName   = "devforge"
+	repoName   = "dev-toolkit"
 	binaryName = "dev"
 )
 
@@ -634,7 +634,7 @@ func newSystemClearLogsCmd() *cobra.Command {
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Show devforge version",
+		Short: "Show dev-toolkit version",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			cmd.Printf("%s\n", version)
@@ -647,8 +647,8 @@ func newSelfUpdateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "self-update",
-		Short: "Update devforge to the latest version",
-		Long:  "Download and install the latest version of devforge from GitHub releases.",
+		Short: "Update dev-toolkit to the latest version",
+		Long:  "Download and install the latest version of dev-toolkit from GitHub releases.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			c := selfupdate.NewCommand(repoOwner, repoName, binaryName, version)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rios0rios0/devforge
+module github.com/rios0rios0/dev-toolkit
 
 go 1.26.2
 

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 #
-# DevForge Installation Script
+# Dev-Toolkit Installation Script
 #
-# Downloads and installs devforge from GitHub releases.
+# Downloads and installs dev-toolkit from GitHub releases.
 # Automatically detects your operating system and architecture.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | sh
-#   wget -qO- https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh | sh
+#   wget -qO- https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh | sh
 #
 # Options:
 #   --help              Show this help message
@@ -17,25 +17,25 @@
 #   --dry-run           Show what would be done without installing
 #
 # Environment variables:
-#   DEVFORGE_INSTALL_DIR   Installation directory (default: ~/.local/bin)
-#   DEVFORGE_VERSION       Specific version to install (default: latest)
-#   DEVFORGE_FORCE         Force installation (true/false, default: false)
-#   DEVFORGE_DRY_RUN       Dry run mode (true/false, default: false)
+#   DEV_TOOLKIT_INSTALL_DIR   Installation directory (default: ~/.local/bin)
+#   DEV_TOOLKIT_VERSION       Specific version to install (default: latest)
+#   DEV_TOOLKIT_FORCE         Force installation (true/false, default: false)
+#   DEV_TOOLKIT_DRY_RUN       Dry run mode (true/false, default: false)
 #
 
 set -e
 
 # Project configuration
 REPO_OWNER="rios0rios0"
-REPO_NAME="devforge"
+REPO_NAME="dev-toolkit"
 BINARY_NAME="dev"
 
 # Defaults
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
-INSTALL_DIR="${DEVFORGE_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-VERSION="${DEVFORGE_VERSION:-latest}"
-FORCE="${DEVFORGE_FORCE:-false}"
-DRY_RUN="${DEVFORGE_DRY_RUN:-false}"
+INSTALL_DIR="${DEV_TOOLKIT_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+VERSION="${DEV_TOOLKIT_VERSION:-latest}"
+FORCE="${DEV_TOOLKIT_FORCE:-false}"
+DRY_RUN="${DEV_TOOLKIT_DRY_RUN:-false}"
 
 # GitHub API
 GITHUB_API_BASE="https://api.github.com"
@@ -70,10 +70,10 @@ OPTIONS:
     --dry-run           Show what would be done without installing
 
 ENVIRONMENT VARIABLES:
-    DEVFORGE_INSTALL_DIR   Installation directory
-    DEVFORGE_VERSION       Specific version to install (default: latest)
-    DEVFORGE_FORCE         Force installation (true/false)
-    DEVFORGE_DRY_RUN       Dry run mode (true/false)
+    DEV_TOOLKIT_INSTALL_DIR   Installation directory
+    DEV_TOOLKIT_VERSION       Specific version to install (default: latest)
+    DEV_TOOLKIT_FORCE         Force installation (true/false)
+    DEV_TOOLKIT_DRY_RUN       Dry run mode (true/false)
 
 EXAMPLES:
     $0

--- a/internal/docker/ips_test.go
+++ b/internal/docker/ips_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/docker"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/docker"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunIPs(t *testing.T) {

--- a/internal/docker/reset_test.go
+++ b/internal/docker/reset_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/docker"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/docker"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunReset(t *testing.T) {

--- a/internal/gist/clone.go
+++ b/internal/gist/clone.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
 	logger "github.com/sirupsen/logrus"
 )
 

--- a/internal/gist/clone_test.go
+++ b/internal/gist/clone_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/gist"
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestComputeDiff(t *testing.T) {

--- a/internal/gist/gist_test.go
+++ b/internal/gist/gist_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
 )
 
 func TestSlug(t *testing.T) {

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
 )
 
 func createGistRepo(t *testing.T, path string) {

--- a/internal/gist/sync.go
+++ b/internal/gist/sync.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
 	logger "github.com/sirupsen/logrus"
 )
 

--- a/internal/gist/sync_test.go
+++ b/internal/gist/sync_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/gist"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunSync(t *testing.T) {

--- a/internal/project/build_test.go
+++ b/internal/project/build_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunBuild(t *testing.T) {

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunInfoDisplaysNoneForEmptyFields(t *testing.T) {

--- a/internal/project/detect_version_test.go
+++ b/internal/project/detect_version_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/rios0rios0/devforge/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
 )
 
 func TestReadRequiredSDKVersion(t *testing.T) {

--- a/internal/project/devconfig_test.go
+++ b/internal/project/devconfig_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestFileConfigReader(t *testing.T) {

--- a/internal/project/info_test.go
+++ b/internal/project/info_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunInfo(t *testing.T) {

--- a/internal/project/lint_test.go
+++ b/internal/project/lint_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunLint(t *testing.T) {

--- a/internal/project/orchestrate_test.go
+++ b/internal/project/orchestrate_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunStartWithDeps(t *testing.T) {

--- a/internal/project/sast_test.go
+++ b/internal/project/sast_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunSAST(t *testing.T) {

--- a/internal/project/start_test.go
+++ b/internal/project/start_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunStart(t *testing.T) {

--- a/internal/project/stop_test.go
+++ b/internal/project/stop_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunStop(t *testing.T) {

--- a/internal/project/test_test.go
+++ b/internal/project/test_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunTest(t *testing.T) {

--- a/internal/project/use_test.go
+++ b/internal/project/use_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/project"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunUse(t *testing.T) {

--- a/internal/repo/clone_test.go
+++ b/internal/repo/clone_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/builders"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/builders"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestComputeDiff(t *testing.T) {

--- a/internal/repo/failover_test.go
+++ b/internal/repo/failover_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunFailover(t *testing.T) {

--- a/internal/repo/fork_sync_test.go
+++ b/internal/repo/fork_sync_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/builders"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/builders"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunForkSync(t *testing.T) {

--- a/internal/repo/mirror_test.go
+++ b/internal/repo/mirror_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunMirror(t *testing.T) {

--- a/internal/repo/provider_test.go
+++ b/internal/repo/provider_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
 )
 
 func TestDetectProviderAndOwner(t *testing.T) {
@@ -88,13 +88,13 @@ func TestKey(t *testing.T) {
 	t.Run("should return name when project is empty", func(t *testing.T) {
 		t.Parallel()
 		// given
-		r := globalEntities.Repository{Name: "devforge"}
+		r := globalEntities.Repository{Name: "dev-toolkit"}
 
 		// when
 		key := repo.Key(r)
 
 		// then
-		assert.Equal(t, "devforge", key)
+		assert.Equal(t, "dev-toolkit", key)
 	})
 
 	t.Run("should return project/name when project is set", func(t *testing.T) {

--- a/internal/repo/prune_test.go
+++ b/internal/repo/prune_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestListMergedBranches(t *testing.T) {

--- a/internal/repo/restore_test.go
+++ b/internal/repo/restore_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunRestore(t *testing.T) {

--- a/internal/repo/scanner_test.go
+++ b/internal/repo/scanner_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
 )
 
 func createGitRepo(t *testing.T, path string) {

--- a/internal/repo/sync_test.go
+++ b/internal/repo/sync_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/repo"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestDetectDefaultBranch(t *testing.T) {

--- a/internal/system/cleanup_test.go
+++ b/internal/system/cleanup_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/system"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/system"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 // testHome is the synthetic home directory used by every cleanup harness.

--- a/internal/system/clear_history_test.go
+++ b/internal/system/clear_history_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/system"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/system"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunClearHistory(t *testing.T) {

--- a/internal/system/clear_logs_test.go
+++ b/internal/system/clear_logs_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/system"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/system"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunClearLogs(t *testing.T) {

--- a/internal/system/top5size_test.go
+++ b/internal/system/top5size_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rios0rios0/devforge/internal/system"
-	"github.com/rios0rios0/devforge/internal/testutil/doubles"
+	"github.com/rios0rios0/dev-toolkit/internal/system"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
 )
 
 func TestRunTop5Size(t *testing.T) {

--- a/internal/testutil/doubles/config_reader_stub.go
+++ b/internal/testutil/doubles/config_reader_stub.go
@@ -1,6 +1,6 @@
 package doubles
 
-import "github.com/rios0rios0/devforge/internal/project"
+import "github.com/rios0rios0/dev-toolkit/internal/project"
 
 // ConfigReaderStub is a test double for project.ConfigReader.
 type ConfigReaderStub struct {

--- a/internal/testutil/doubles/fork_resolver_stub.go
+++ b/internal/testutil/doubles/fork_resolver_stub.go
@@ -3,7 +3,7 @@ package doubles
 import (
 	"context"
 
-	"github.com/rios0rios0/devforge/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
 )
 
 // ForkResolverStub is a test double for repo.ForkResolver.

--- a/internal/testutil/doubles/gist_provider_stub.go
+++ b/internal/testutil/doubles/gist_provider_stub.go
@@ -3,7 +3,7 @@ package doubles
 import (
 	"context"
 
-	"github.com/rios0rios0/devforge/internal/gist"
+	"github.com/rios0rios0/dev-toolkit/internal/gist"
 )
 
 // GistProviderStub is a configurable test double for gist.Provider.

--- a/internal/testutil/doubles/language_detector_multi_stub.go
+++ b/internal/testutil/doubles/language_detector_multi_stub.go
@@ -3,7 +3,7 @@ package doubles
 import (
 	"fmt"
 
-	"github.com/rios0rios0/devforge/internal/project"
+	"github.com/rios0rios0/dev-toolkit/internal/project"
 )
 
 // LanguageDetectorMultiStub is a path-aware test double for project.LanguageDetector.

--- a/internal/testutil/doubles/language_detector_stub.go
+++ b/internal/testutil/doubles/language_detector_stub.go
@@ -1,6 +1,6 @@
 package doubles
 
-import "github.com/rios0rios0/devforge/internal/project"
+import "github.com/rios0rios0/dev-toolkit/internal/project"
 
 // LanguageDetectorStub is a test double for project.LanguageDetector.
 type LanguageDetectorStub struct {


### PR DESCRIPTION
## Summary

Renames the project from `devforge` to `dev-toolkit` to reserve the `forge` suffix for libraries (`gitforge`, `langforge`, `cliforge`) and keep CLI naming distinct from the library family.

The binary name remains `dev`, so end-users running the installed CLI see no change.

## Changes

- Go module path: `github.com/rios0rios0/devforge` → `github.com/rios0rios0/dev-toolkit`
- Directory: `cmd/devforge/` → `cmd/dev-toolkit/`
- `install.sh` env var prefix: `DEVFORGE_*` → `DEV_TOOLKIT_*`
- Updated `Makefile`, `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.gitignore`
- Added `[Unreleased] > Changed` entries to `CHANGELOG.md`
- Historical `CHANGELOG.md` entries (the `versainit` → `devforge` migration) preserved as-is
- `gitforge`/`langforge`/`cliforge` external library deps and the `ForgeProvider`/`Forgejo` upstream identifiers remain untouched

## Notes for downstream

- Old `go install github.com/rios0rios0/devforge/cmd/devforge@latest` paths break (GitHub repo redirect won't help the Go module proxy). Use the `install.sh` flow or the new module path after merge.
- Sibling repo `dotfiles` will get a paired PR updating the install script function names and references.
- After merge, the GitHub repo will be renamed to `rios0rios0/dev-toolkit` (auto-redirects).

## Test plan

- [x] `make build` succeeds with new module path
- [x] `go test ./...` — all packages pass
- [x] `bin/dev version` reports correct version
- [x] `bin/dev --help` shows correct branding (`Update dev-toolkit to the latest version`)
- [ ] Post-merge: rename GitHub repo and verify install.sh download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)