### PR TITLE
fix(security): harden directory permissions to owner-only (resolve Semgrep incorrect-default-permission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Security
+
+- hardened directory permissions from `0o750` to owner-only `0o700` in the SAST report and Git clone helpers and their test fixtures, resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
+
 ## [0.8.16] - 2026-07-14
 
 ### Changed

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -15,7 +15,7 @@ func createGistRepo(t *testing.T, path string) {
 	t.Helper()
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	err := os.MkdirAll(filepath.Join(path, ".git"), 0o700)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestScanLocalGists(t *testing.T) {

--- a/internal/gist/scanner_test.go
+++ b/internal/gist/scanner_test.go
@@ -13,7 +13,8 @@ import (
 
 func createGistRepo(t *testing.T, path string) {
 	t.Helper()
-	err := os.MkdirAll(filepath.Join(path, ".git"), 0o750)
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	err := os.MkdirAll(filepath.Join(path, ".git"), 0o700)
 	assert.NoError(t, err)
 }
 
@@ -44,7 +45,8 @@ func TestScanLocalGists(t *testing.T) {
 		// given
 		root := t.TempDir()
 		createGistRepo(t, filepath.Join(root, "real-gist"))
-		err := os.MkdirAll(filepath.Join(root, "not-a-gist"), 0o750)
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		err := os.MkdirAll(filepath.Join(root, "not-a-gist"), 0o700)
 		require.NoError(t, err)
 
 		// when

--- a/internal/project/sast.go
+++ b/internal/project/sast.go
@@ -98,7 +98,7 @@ func ensureReportDir(repoPath, toolName string) (string, error) {
 	// 0o600 file threshold) is the least-privilege mode, and owner-only is sufficient here.
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("failed to create report directory: %w", err)
+		return "", fmt.Errorf("failed to create report directory %s: %w", dir, err)
 	}
 	return dir, nil
 }

--- a/internal/project/sast.go
+++ b/internal/project/sast.go
@@ -94,7 +94,10 @@ func RunSAST(cfg Config) error {
 // ensureReportDir creates the report directory for a tool under build/reports/<tool>.
 func ensureReportDir(repoPath, toolName string) (string, error) {
 	dir := filepath.Join(repoPath, "build", "reports", toolName)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
+	// Report output dir; a directory needs the owner execute bit, so 0o700 (not the rule's
+	// 0o600 file threshold) is the least-privilege mode, and owner-only is sufficient here.
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("failed to create report directory: %w", err)
 	}
 	return dir, nil

--- a/internal/repo/git.go
+++ b/internal/repo/git.go
@@ -42,7 +42,10 @@ func (r *DefaultGitRunner) Output(dir string, args ...string) string {
 }
 
 func (r *DefaultGitRunner) Clone(url, target string) error {
-	if mkdirErr := os.MkdirAll(filepath.Dir(target), 0o750); mkdirErr != nil {
+	// Clone target's parent dir; a directory needs the owner execute bit, so 0o700 (not the
+	// rule's 0o600 file threshold) is the least-privilege mode, and owner-only is sufficient.
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	if mkdirErr := os.MkdirAll(filepath.Dir(target), 0o700); mkdirErr != nil {
 		return mkdirErr
 	}
 

--- a/internal/repo/git.go
+++ b/internal/repo/git.go
@@ -42,11 +42,12 @@ func (r *DefaultGitRunner) Output(dir string, args ...string) string {
 }
 
 func (r *DefaultGitRunner) Clone(url, target string) error {
-	// Clone target's parent dir; a directory needs the owner execute bit, so 0o700 (not the
-	// rule's 0o600 file threshold) is the least-privilege mode, and owner-only is sufficient.
+	parentDir := filepath.Dir(target)
+	// A directory needs the owner execute bit, so 0o700 (not the rule's 0o600 file threshold)
+	// is the least-privilege mode, and owner-only is sufficient.
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
-	if mkdirErr := os.MkdirAll(filepath.Dir(target), 0o700); mkdirErr != nil {
-		return mkdirErr
+	if mkdirErr := os.MkdirAll(parentDir, 0o700); mkdirErr != nil {
+		return fmt.Errorf("failed to create clone parent directory %s: %w", parentDir, mkdirErr)
 	}
 
 	cmd := exec.CommandContext(

--- a/internal/repo/mirror_test.go
+++ b/internal/repo/mirror_test.go
@@ -155,5 +155,6 @@ func TestRunMirror(t *testing.T) {
 
 func createDirStructure(t *testing.T, root, path string) {
 	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, path), 0o750))
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.MkdirAll(filepath.Join(root, path), 0o700))
 }

--- a/internal/repo/scanner_test.go
+++ b/internal/repo/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rios0rios0/dev-toolkit/internal/repo"
 )
@@ -14,7 +15,7 @@ func createGitRepo(t *testing.T, path string) {
 	t.Helper()
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	err := os.MkdirAll(filepath.Join(path, ".git"), 0o700)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestScanFlatRepos(t *testing.T) {
@@ -42,7 +43,7 @@ func TestScanFlatRepos(t *testing.T) {
 		root := t.TempDir()
 		createGitRepo(t, filepath.Join(root, "repo-a"))
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
-		_ = os.MkdirAll(filepath.Join(root, "not-a-repo"), 0o700)
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "not-a-repo"), 0o700))
 
 		// when
 		repos := repo.ScanFlatRepos(root)
@@ -115,7 +116,7 @@ func TestScanNestedRepos(t *testing.T) {
 		root := t.TempDir()
 		createGitRepo(t, filepath.Join(root, "backend", "catalog"))
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
-		_ = os.MkdirAll(filepath.Join(root, "empty-project"), 0o700)
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "empty-project"), 0o700))
 
 		// when
 		repos := repo.ScanNestedRepos(root)
@@ -192,7 +193,7 @@ func TestFindAllRepos(t *testing.T) {
 		// given
 		root := t.TempDir()
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
-		_ = os.MkdirAll(filepath.Join(root, ".git"), 0o700)
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o700))
 		createGitRepo(t, filepath.Join(root, "child"))
 
 		// when
@@ -207,7 +208,7 @@ func TestFindAllRepos(t *testing.T) {
 		// given
 		root := t.TempDir()
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
-		_ = os.MkdirAll(filepath.Join(root, "empty"), 0o700)
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "empty"), 0o700))
 
 		// when
 		repos := repo.FindAllRepos(root)

--- a/internal/repo/scanner_test.go
+++ b/internal/repo/scanner_test.go
@@ -12,7 +12,8 @@ import (
 
 func createGitRepo(t *testing.T, path string) {
 	t.Helper()
-	err := os.MkdirAll(filepath.Join(path, ".git"), 0o750)
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	err := os.MkdirAll(filepath.Join(path, ".git"), 0o700)
 	assert.NoError(t, err)
 }
 
@@ -40,7 +41,8 @@ func TestScanFlatRepos(t *testing.T) {
 		// given
 		root := t.TempDir()
 		createGitRepo(t, filepath.Join(root, "repo-a"))
-		_ = os.MkdirAll(filepath.Join(root, "not-a-repo"), 0o750)
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		_ = os.MkdirAll(filepath.Join(root, "not-a-repo"), 0o700)
 
 		// when
 		repos := repo.ScanFlatRepos(root)
@@ -112,7 +114,8 @@ func TestScanNestedRepos(t *testing.T) {
 		// given
 		root := t.TempDir()
 		createGitRepo(t, filepath.Join(root, "backend", "catalog"))
-		_ = os.MkdirAll(filepath.Join(root, "empty-project"), 0o750)
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		_ = os.MkdirAll(filepath.Join(root, "empty-project"), 0o700)
 
 		// when
 		repos := repo.ScanNestedRepos(root)
@@ -188,7 +191,8 @@ func TestFindAllRepos(t *testing.T) {
 		t.Parallel()
 		// given
 		root := t.TempDir()
-		_ = os.MkdirAll(filepath.Join(root, ".git"), 0o750)
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		_ = os.MkdirAll(filepath.Join(root, ".git"), 0o700)
 		createGitRepo(t, filepath.Join(root, "child"))
 
 		// when
@@ -202,7 +206,8 @@ func TestFindAllRepos(t *testing.T) {
 		t.Parallel()
 		// given
 		root := t.TempDir()
-		_ = os.MkdirAll(filepath.Join(root, "empty"), 0o750)
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		_ = os.MkdirAll(filepath.Join(root, "empty"), 0o700)
 
 		// when
 		repos := repo.FindAllRepos(root)


### PR DESCRIPTION
## Problem

CI `sast:semgrep` fails on `main` with 10 blocking findings, all of the same rule:

```
go.lang.correctness.permissions.file_permission.incorrect-default-permission
```

The rule (a gosec G301/G302 port, CWE-276) flags `os.Chmod/Mkdir/OpenFile/MkdirAll/ioutil.WriteFile` whenever the mode is **strictly greater than `0o600`**.

## Root cause

Every finding is an `os.MkdirAll(..., 0o750)` **directory** creation:

- `internal/project/sast.go` — `build/reports/<tool>` output dir (production)
- `internal/repo/git.go` — clone target's parent dir (production)
- 3 test files creating temp fixture directories

Two facts drive the fix:

1. `0o750` grants group read/traverse the process never needs — tightening to `0o700` is a genuine least-privilege improvement.
2. A directory must keep the owner *execute* (search) bit or files cannot be created/read inside it (`0o600` dir ⇒ `permission denied`). So the rule's `0o600` threshold cannot be met by a working directory; `0o700` is the least-privilege mode.

## Fix

- **Hardened** every flagged `os.MkdirAll` from `0o750` to owner-only **`0o700`** (removes group access).
- For the irreducible residual (`0o700` still trips the rule's file-oriented threshold), added a **rule-scoped** `// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission`. Both production sites carry an inline rationale; the rule stays active elsewhere.
- `CHANGELOG.md` updated under `[Unreleased] > Security`.

Verified locally: `golangci-lint` (pipelines config) → 0 issues; `go build ./...` OK; `gofmt` clean; the directive suppresses all findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)