### PR TITLE
feat(worktree): added linked worktree inspection and cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,8 @@ Always reference these instructions first and fallback to search or bash command
 - Sync repos: `./bin/dev repo sync ~/Development/github.com/rios0rios0`
 - Fork sync: `./bin/dev repo fork-sync ~/Development/github.com/rios0rios0`
 - Prune branches: `./bin/dev repo prune ~/Development/github.com/rios0rios0`
+- List worktrees: `./bin/dev repo worktree list ~/Development/github.com/rios0rios0`
+- Prune worktrees: `./bin/dev repo worktree prune ~/Development/github.com/rios0rios0`
 - Mirror to Codeberg: `./bin/dev repo mirror mine ~/Development/github.com/rios0rios0`
 - Failover to Codeberg: `./bin/dev repo failover ~/Development/github.com/rios0rios0`
 - Restore from failover: `./bin/dev repo restore ~/Development/github.com/rios0rios0`
@@ -49,12 +51,13 @@ Always reference these instructions first and fallback to search or bash command
 3. **Clone dry-run**: `./bin/dev repo clone mine --dry-run ~/Development/github.com/rios0rios0`
 4. **Sync**: `./bin/dev repo sync ~/Development/github.com/rios0rios0`
 5. **Project info**: `./bin/dev project info .` (verifies language detection)
+6. **Worktree dry-run**: `./bin/dev repo worktree prune --dry-run ~/Development/github.com/rios0rios0`
 
 ## Project Structure
 
 ### Key Files and Directories
 - `cmd/dev-toolkit/main.go` -- All CLI wiring (Cobra commands, dependency construction, update check)
-- `internal/repo/` -- Repository operations: clone, sync, fork-sync, prune, mirror, failover, restore
+- `internal/repo/` -- Repository operations: clone, sync, fork-sync, prune, worktree, mirror, failover, restore
 - `internal/project/` -- Language-aware commands: start, build, lint, test, sast, stop, use, info
 - `internal/docker/` -- Docker management: container IPs, environment reset
 - `internal/gist/` -- Gist operations: clone, sync (GitHub gists via SSH with description-derived slugs)
@@ -68,6 +71,7 @@ Always reference these instructions first and fallback to search or bash command
 - **Parallel execution**: Goroutines with semaphore channel for controlled concurrency
 - **SSH preflight**: Verifies SSH connectivity before batch cloning
 - **WIP branches**: Preserves dirty state during sync via temporary commits
+- **Worktree rule tables**: Ordered guard/removal rule slices classify linked worktrees; guards (locked, detached, dirty, unpushed) always win over removal rules
 - **Dependency injection**: All business logic accepts interfaces for testability
 - **SAST orchestration**: Per-tool failure isolation with embedded default configs
 - **Platform gating**: System commands conditionally registered via `runtime.GOOS`

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,9 @@ build
 # this space is for project generated files, DO NOT add personal or IDE files here
 # try to use ~/.gitignore of your user for your workspace generated files
 coverage.out
+coverage.txt
+coverage.xml
+cobertura.xml
+junit.xml
+reports
 dev-toolkit

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
-bin
-build
+/bin
+/build
 
 # this space is for project generated files, DO NOT add personal or IDE files here
 # try to use ~/.gitignore of your user for your workspace generated files
-coverage.out
-coverage.txt
-coverage.xml
-cobertura.xml
-junit.xml
-reports
-dev-toolkit
+/coverage.out
+/coverage.txt
+/coverage.xml
+/cobertura.xml
+/junit.xml
+/reports
+# the built binary at the repo root -- anchored so it does not match cmd/dev-toolkit/
+/dev-toolkit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
+- fixed `dev repo worktree` marking every worktree as living outside the root when the root directory was given as a relative path (e.g. `./backend`): Git reports absolute worktree paths, and `filepath.Rel` fails when only one side is relative, so `isInsideRoot` classified all of them as disposable. The root is now resolved to an absolute path, and an uncomparable path is treated as inside the root so it is never reported as disposable
 - fixed `make test` and `make sast` leaving generated reports (`reports/`, `coverage.txt`, `coverage.xml`, `cobertura.xml`, `junit.xml`) as untracked files by adding them to `.gitignore`
+- fixed the unanchored `dev-toolkit` entry in `.gitignore` also matching the `cmd/dev-toolkit/` source directory, which made any newly added file there impossible to commit; all entries are now anchored to the repository root
 - fixed linked Git worktrees being invisible to every repository workflow: `ScanFlatRepos`, `ScanNestedRepos`, and `FindAllRepos` required `.git` to be a directory, but a linked worktree stores `.git` as a file, so worktrees were silently skipped by `clone`, `sync`, `prune`, and the remaining repo commands. Worktrees are deliberately kept out of the clone remote-vs-local diff -- they are extra checkouts of repositories that do exist on the remote, so deleting them as "extra" would corrupt the parent repository's metadata -- and are handled by the dedicated `worktree` commands instead
 
 ## [0.8.17] - 2026-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `dev repo worktree list` to report every linked Git worktree under a directory together with the reason it is disposable or protected
+- added `dev repo worktree prune` to remove linked worktrees that outlived their purpose: stale registrations whose directory is gone, worktrees living outside the scanned root, worktrees whose branch is merged into the default branch, and worktrees whose upstream branch was deleted on the remote
+- added a `--prune-worktrees` flag to `dev repo clone` that runs the same worktree cleanup pass after the clone workflow
+
+### Fixed
+
+- fixed `make test` and `make sast` leaving generated reports (`reports/`, `coverage.txt`, `coverage.xml`, `cobertura.xml`, `junit.xml`) as untracked files by adding them to `.gitignore`
+- fixed linked Git worktrees being invisible to every repository workflow: `ScanFlatRepos`, `ScanNestedRepos`, and `FindAllRepos` required `.git` to be a directory, but a linked worktree stores `.git` as a file, so worktrees were silently skipped by `clone`, `sync`, `prune`, and the remaining repo commands. Worktrees are deliberately kept out of the clone remote-vs-local diff -- they are extra checkouts of repositories that do exist on the remote, so deleting them as "extra" would corrupt the parent repository's metadata -- and are handled by the dedicated `worktree` commands instead
+
 ## [0.8.17] - 2026-07-16
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ dev repo fork-sync ~/Development/github.com/rios0rios0          # sync forks wit
 dev repo fork-sync ~/Development/github.com/rios0rios0 --dry-run # preview fork sync
 dev repo prune ~/Development/github.com/rios0rios0              # delete merged branches
 dev repo prune ~/Development/github.com/rios0rios0 --dry-run    # preview without deleting
+dev repo worktree list ~/Development/github.com/rios0rios0      # list linked worktrees + classification
+dev repo worktree prune ~/Development/github.com/rios0rios0     # remove disposable worktrees (prompts)
+dev repo worktree prune ~/Development/github.com/rios0rios0 --dry-run  # preview without removing
+dev repo worktree prune ~/Development/github.com/rios0rios0 --yes     # remove without prompting
+dev repo clone mine --prune-worktrees                           # clone, then clean up worktrees
 dev repo mirror mine ~/Development/github.com/rios0rios0        # create Codeberg pull mirrors
 dev repo failover ~/Development/github.com/rios0rios0           # switch repos to Codeberg primary
 dev repo restore ~/Development/github.com/rios0rios0            # restore GitHub as primary remote
@@ -73,6 +78,7 @@ internal/
     fork_resolver_github.go  -- GitHub implementation using go-github API
     fork_sync.go             -- fork-sync orchestration: detect forks, add upstream, rebase, handle conflicts
     prune.go                 -- prune merged branches with dry-run support
+    worktree.go              -- linked worktree parsing, rule-based classification, and cleanup
     mirror.go                -- create Codeberg pull mirrors via Forgejo migration API
     failover.go              -- switch repos from GitHub to Codeberg as primary remote
     restore.go               -- restore GitHub as primary remote after failover
@@ -132,6 +138,8 @@ internal/
 - **Docker operations**: Uses `exec.Command("docker", ...)` behind `docker.Runner` interface for testability
 - **System operations**: Uses `exec.Command(...)` behind `system.Runner` and `FileSystem` interfaces; platform-gated via `runtime.GOOS`
 - **Fork sync**: Uses `ForkResolver` interface to query provider APIs for parent repo info; auto-adds `upstream` remote
+- **Worktree detection**: A linked worktree stores `.git` as a *file*, so the `.git`-directory scanners (`ScanFlatRepos`, `ScanNestedRepos`, `FindAllRepos`) never see one. This is intentional: worktrees are extra checkouts of repos that exist on the remote, so they must stay out of the clone remote-vs-local diff. `worktree.go` reads them from `git worktree list --porcelain` instead
+- **Worktree classification**: Ordered rule tables (`worktreeGuardRules`, `worktreeRemovalRules`) instead of branching; guards (locked, detached, dirty, unpushed) are always evaluated before removal rules, so preserving work wins over cleaning up. Removal always goes through `git worktree remove`/`git worktree prune`, never `os.RemoveAll`, to keep the parent repo's metadata consistent
 - **SAST orchestration**: Runs each tool (CodeQL, Semgrep, Trivy, Hadolint, Gitleaks) with per-tool failure isolation and embedded default configs
 - **Dependency injection**: Business logic accepts interfaces (`GitRunner`, `ForgeProvider`, `ForkResolver`, `LanguageDetector`, `CommandRunner`, `ConfigReader`, `docker.Runner`, `system.Runner`, `FileSystem`, `io.Writer`) for testability
 - **Project dependencies**: `.dev.yaml` declares relative paths to dependent projects; resolved via DFS topological sort with cycle detection

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dev-Toolkit is a developer workspace toolkit that manages Git repositories acros
 - **Gist Cloning & Syncing**: discovers GitHub gists for a user, clones missing ones via SSH using a description-derived slug, and syncs them with the same WIP-aware workflow as repos
 - **Fork Syncing**: detects forked repos via provider API, syncs with upstream parent, and handles conflicts by creating reference branches
 - **Branch Pruning**: deletes local branches merged into the default branch across all repos
-- **Worktree Cleanup**: finds linked Git worktrees that outlived their purpose -- stale registrations, worktrees outside the root, merged branches, deleted upstreams -- and removes them through `git worktree remove`, protecting anything locked, detached, dirty, or unpushed
+- **Worktree Cleanup**: finds linked Git worktrees that outlived their purpose -- stale registrations, worktrees outside the root, merged branches, deleted upstreams -- and clears them through Git itself (`git worktree prune` for stale registrations, `git worktree remove` for the rest), protecting anything locked, detached, dirty, or unpushed
 - **Docker Management**: lists container IPs and resets the Docker environment (stop, prune)
 - **System Cleanup**: reclaims disk space by clearing caches across Go, Node, Python, Gradle, JetBrains, Terra, and SDKMAN, pruning obsolete CLI-agent binary versions, and wiping transient state -- credentials, SDKs, and shell history are preserved
 - **Multi-Provider Support**: automatic provider detection from directory path with per-provider auth tokens

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dev-Toolkit is a developer workspace toolkit that manages Git repositories acros
 - **Gist Cloning & Syncing**: discovers GitHub gists for a user, clones missing ones via SSH using a description-derived slug, and syncs them with the same WIP-aware workflow as repos
 - **Fork Syncing**: detects forked repos via provider API, syncs with upstream parent, and handles conflicts by creating reference branches
 - **Branch Pruning**: deletes local branches merged into the default branch across all repos
+- **Worktree Cleanup**: finds linked Git worktrees that outlived their purpose -- stale registrations, worktrees outside the root, merged branches, deleted upstreams -- and removes them through `git worktree remove`, protecting anything locked, detached, dirty, or unpushed
 - **Docker Management**: lists container IPs and resets the Docker environment (stop, prune)
 - **System Cleanup**: reclaims disk space by clearing caches across Go, Node, Python, Gradle, JetBrains, Terra, and SDKMAN, pruning obsolete CLI-agent binary versions, and wiping transient state -- credentials, SDKs, and shell history are preserved
 - **Multi-Provider Support**: automatic provider detection from directory path with per-provider auth tokens
@@ -45,6 +46,7 @@ dev repo clone <ssh-alias> [root-dir]
 dev repo clone mine ~/Development/github.com/rios0rios0
 dev repo clone my-org ~/Development/dev.azure.com/my-org
 dev repo clone mine --dry-run  # preview without cloning
+dev repo clone mine --prune-worktrees  # also clean up disposable linked worktrees
 
 # Sync all repos under a directory
 dev repo sync [root-dir]
@@ -58,6 +60,13 @@ dev repo fork-sync --dry-run     # preview without syncing
 # Delete local merged branches
 dev repo prune [root-dir]
 dev repo prune ~/Development/github.com/rios0rios0 --dry-run
+
+# Inspect and clean up linked worktrees (run before "repo prune": a branch checked
+# out in a worktree cannot be deleted by "git branch -d")
+dev repo worktree list [root-dir]
+dev repo worktree prune [root-dir]           # confirm each removal interactively
+dev repo worktree prune ~/Development/github.com/rios0rios0 --dry-run
+dev repo worktree prune ~/Development/github.com/rios0rios0 --yes  # no prompts
 
 # Clone all GitHub gists for a user (slug derived from description; falls back to gist ID)
 dev gist clone <ssh-alias> [root-dir]

--- a/cmd/dev-toolkit/main.go
+++ b/cmd/dev-toolkit/main.go
@@ -308,11 +308,15 @@ confirmed interactively unless --yes is given.`,
 }
 
 // rootDirFromArgs resolves the optional root-dir argument, defaulting to the
-// current working directory.
+// current working directory. The result is absolute so it can be compared against
+// the absolute paths git reports for worktrees.
 func rootDirFromArgs(args []string) string {
 	rootDir, _ := os.Getwd()
 	if len(args) > 0 {
 		rootDir = args[0]
+	}
+	if abs, err := filepath.Abs(rootDir); err == nil {
+		return abs
 	}
 	return filepath.Clean(rootDir)
 }

--- a/cmd/dev-toolkit/main.go
+++ b/cmd/dev-toolkit/main.go
@@ -57,6 +57,7 @@ func main() {
 	repoCmd.AddCommand(newSyncCmd())
 	repoCmd.AddCommand(newForkSyncCmd())
 	repoCmd.AddCommand(newPruneCmd())
+	repoCmd.AddCommand(newWorktreeCmd())
 	repoCmd.AddCommand(newMirrorCmd())
 	repoCmd.AddCommand(newFailoverCmd())
 	repoCmd.AddCommand(newRestoreCmd())
@@ -115,12 +116,17 @@ func main() {
 func newCloneCmd() *cobra.Command {
 	var dryRun bool
 	var includeArchived bool
+	var pruneWorktrees bool
 
 	cmd := &cobra.Command{
 		Use:   "clone <ssh-alias> [root-dir]",
 		Short: "Clone missing repositories from a Git provider",
 		Long: `Discovers repositories from the Git provider, compares with local directories,
-clones missing repos via SSH, and optionally removes extra local repos.`,
+clones missing repos via SSH, and optionally removes extra local repos.
+
+Linked worktrees are not part of that comparison: they are extra checkouts of
+repositories that do exist on the remote. Pass --prune-worktrees to also run the
+worktree cleanup pass (the same one as "dev repo worktree prune") afterwards.`,
 		Args: cobra.RangeArgs(1, repo.MaxCloneArgs()),
 		RunE: func(_ *cobra.Command, args []string) error {
 			sshAlias := args[0]
@@ -140,6 +146,7 @@ clones missing repos via SSH, and optionally removes extra local repos.`,
 				SSHAlias:        sshAlias,
 				DryRun:          dryRun,
 				IncludeArchived: includeArchived,
+				PruneWorktrees:  pruneWorktrees,
 				Provider:        provider,
 				Runner:          &repo.DefaultGitRunner{},
 				Output:          os.Stderr,
@@ -150,6 +157,8 @@ clones missing repos via SSH, and optionally removes extra local repos.`,
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be done without making changes")
 	cmd.Flags().BoolVar(&includeArchived, "include-archived", false, "include archived repositories")
+	cmd.Flags().BoolVar(&pruneWorktrees, "prune-worktrees", false,
+		"also clean up disposable linked worktrees after cloning")
 
 	return cmd
 }
@@ -238,6 +247,74 @@ lists local branches merged into the default branch and deletes them.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show which branches would be deleted without deleting them")
 
 	return cmd
+}
+
+func newWorktreeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "worktree",
+		Short: "Inspect and clean up linked Git worktrees",
+	}
+	cmd.AddCommand(newWorktreeListCmd())
+	cmd.AddCommand(newWorktreePruneCmd())
+	return cmd
+}
+
+func newWorktreeListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list [root-dir]",
+		Short: "List linked worktrees and whether they are disposable",
+		Long: `For each repository found under the root directory, lists every linked
+worktree together with the reason it is either disposable or protected.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return repo.RunWorktreeList(rootDirFromArgs(args), &repo.DefaultGitRunner{}, os.Stderr)
+		},
+	}
+}
+
+func newWorktreePruneCmd() *cobra.Command {
+	var dryRun bool
+	var assumeYes bool
+
+	cmd := &cobra.Command{
+		Use:   "prune [root-dir]",
+		Short: "Remove disposable linked worktrees",
+		Long: `For each repository found under the root directory, removes linked worktrees
+that are no longer useful: stale registrations whose directory is gone, worktrees
+living outside the root directory, worktrees whose branch is merged into the
+default branch, and worktrees whose upstream branch was deleted on the remote.
+
+Removal always goes through "git worktree remove", so the parent repository's
+metadata stays consistent. Worktrees that are locked, on a detached HEAD, hold
+uncommitted changes, or hold unpushed commits are never removed. Each removal is
+confirmed interactively unless --yes is given.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return repo.RunWorktreePrune(repo.WorktreePruneConfig{
+				RootDir:   rootDirFromArgs(args),
+				DryRun:    dryRun,
+				AssumeYes: assumeYes,
+				Runner:    &repo.DefaultGitRunner{},
+				Output:    os.Stderr,
+				Input:     os.Stdin,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show which worktrees would be removed without removing them")
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "remove without prompting for confirmation")
+
+	return cmd
+}
+
+// rootDirFromArgs resolves the optional root-dir argument, defaulting to the
+// current working directory.
+func rootDirFromArgs(args []string) string {
+	rootDir, _ := os.Getwd()
+	if len(args) > 0 {
+		rootDir = args[0]
+	}
+	return filepath.Clean(rootDir)
 }
 
 func newGistCloneCmd() *cobra.Command {

--- a/internal/repo/clone.go
+++ b/internal/repo/clone.go
@@ -29,6 +29,7 @@ type CloneConfig struct {
 	SSHAlias        string
 	DryRun          bool
 	IncludeArchived bool
+	PruneWorktrees  bool
 	Provider        globalEntities.ForgeProvider
 	Runner          GitRunner
 	Output          io.Writer
@@ -78,7 +79,7 @@ func RunClone(cfg CloneConfig) error {
 
 	if len(missing) == 0 && len(extra) == 0 {
 		log.Info("everything is in sync")
-		return nil
+		return PruneWorktreesForClone(cfg, log)
 	}
 
 	cloned, failed := CloneMissing(missing, cfg)
@@ -89,7 +90,25 @@ func RunClone(cfg CloneConfig) error {
 		mirrorStatusFailed: failed,
 		"extra":            len(extra),
 	}).Info("clone workflow completed")
-	return nil
+	return PruneWorktreesForClone(cfg, log)
+}
+
+// PruneWorktreesForClone runs the worktree cleanup pass when the clone command was
+// asked for it. Linked worktrees are deliberately absent from the remote-vs-local
+// diff above: they are extra checkouts of repositories that do exist on the remote,
+// not repositories missing from it.
+func PruneWorktreesForClone(cfg CloneConfig, log logger.FieldLogger) error {
+	if !cfg.PruneWorktrees {
+		return nil
+	}
+	return RunWorktreePrune(WorktreePruneConfig{
+		RootDir: cfg.RootDir,
+		DryRun:  cfg.DryRun,
+		Runner:  cfg.Runner,
+		Output:  cfg.Output,
+		Input:   cfg.Input,
+		Logger:  log,
+	})
 }
 
 // DiscoverRepos fetches repositories from the provider and optionally filters archived ones.

--- a/internal/repo/clone_test.go
+++ b/internal/repo/clone_test.go
@@ -708,3 +708,105 @@ func TestHandleExtraRepos(t *testing.T) {
 		assert.Empty(t, buf.String())
 	})
 }
+
+func TestRunCloneWithPruneWorktrees(t *testing.T) {
+	t.Parallel()
+
+	// cloneRootWithWorktree builds a provider-detectable root holding one repo whose
+	// merged worktree is a removal candidate.
+	setup := func(t *testing.T) (string, *doubles.GitRunnerStub, *doubles.ForgeProviderStub) {
+		t.Helper()
+		root := t.TempDir() + "/github.com/owner"
+		createGitRepo(t, root+"/repo-a")
+		porcelain := "worktree " + root + "/repo-a\nHEAD abc\nbranch refs/heads/main\n\n" +
+			"worktree " + root + "/repo-a-wt\nHEAD def\nbranch refs/heads/feat/done\n"
+		runner := doubles.NewGitRunnerStub().
+			WithOutput([]string{"worktree", "list", "--porcelain"}, porcelain).
+			WithOutput([]string{"symbolic-ref", "refs/remotes/origin/HEAD"}, "refs/remotes/origin/main").
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done")
+		provider := doubles.NewForgeProviderStub().WithRepos([]globalEntities.Repository{
+			builders.NewRepositoryBuilder().WithName("repo-a").Build(),
+		})
+		return root, runner, provider
+	}
+
+	t.Run("should leave worktrees alone when the flag is not set", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root, runner, provider := setup(t)
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunClone(repo.CloneConfig{
+			RootDir:  root,
+			SSHAlias: "mine",
+			DryRun:   true,
+			Provider: provider,
+			Runner:   runner,
+			Output:   &buf,
+			Logger:   repo.NewLogger(&buf),
+			Input:    strings.NewReader(""),
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotContains(t, buf.String(), "worktree")
+	})
+
+	t.Run("should run the worktree pass when the flag is set", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root, runner, provider := setup(t)
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunClone(repo.CloneConfig{
+			RootDir:        root,
+			SSHAlias:       "mine",
+			DryRun:         true,
+			PruneWorktrees: true,
+			Provider:       provider,
+			Runner:         runner,
+			Output:         &buf,
+			Logger:         repo.NewLogger(&buf),
+			Input:          strings.NewReader(""),
+		})
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "everything is in sync")
+		assert.Contains(t, output, "would remove worktree")
+		assert.Contains(t, output, "repo-a-wt")
+	})
+
+	t.Run("should run the worktree pass after cloning missing repos", func(t *testing.T) {
+		t.Parallel()
+		// given a remote repo that is missing locally, so the sync shortcut is skipped
+		root, runner, _ := setup(t)
+		provider := doubles.NewForgeProviderStub().WithRepos([]globalEntities.Repository{
+			builders.NewRepositoryBuilder().WithName("repo-a").Build(),
+			builders.NewRepositoryBuilder().WithName("repo-b").Build(),
+		})
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunClone(repo.CloneConfig{
+			RootDir:        root,
+			SSHAlias:       "mine",
+			DryRun:         true,
+			PruneWorktrees: true,
+			Provider:       provider,
+			Runner:         runner,
+			Output:         &buf,
+			Logger:         repo.NewLogger(&buf),
+			Input:          strings.NewReader(""),
+		})
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "clone workflow completed")
+		assert.Contains(t, output, "would remove worktree")
+	})
+}

--- a/internal/repo/worktree.go
+++ b/internal/repo/worktree.go
@@ -134,12 +134,27 @@ type worktreeEnv struct {
 	runner  GitRunner
 }
 
+// isInsideRoot reports whether the worktree lives under the scanned root. Git always
+// reports absolute worktree paths, so the root is resolved to an absolute path too:
+// [filepath.Rel] fails when only one side is relative, which would otherwise mark
+// every worktree as living outside the root.
 func (e worktreeEnv) isInsideRoot(w Worktree) bool {
-	rel, err := filepath.Rel(e.rootDir, w.Path)
+	rel, err := filepath.Rel(e.rootDir, absPathOrOriginal(w.Path))
 	if err != nil {
-		return false
+		// Fail safe: a path that cannot be compared must never be reported as disposable.
+		return true
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// absPathOrOriginal resolves a path against the working directory, falling back to
+// the input when resolution fails.
+func absPathOrOriginal(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
 }
 
 func (e worktreeEnv) isDirty(w Worktree) bool {
@@ -260,7 +275,7 @@ func ScanWorktrees(repoPath, rootDir string, runner GitRunner) []WorktreeCandida
 
 	defaultBranch := DetectDefaultBranch(repoPath, runner)
 	env := worktreeEnv{
-		rootDir: rootDir,
+		rootDir: absPathOrOriginal(rootDir),
 		merged:  toBranchSet(ListMergedBranches(repoPath, defaultBranch, runner)),
 		gone:    ListGoneBranches(repoPath, runner),
 		runner:  runner,

--- a/internal/repo/worktree.go
+++ b/internal/repo/worktree.go
@@ -1,0 +1,481 @@
+package repo
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	logger "github.com/sirupsen/logrus"
+)
+
+// Removal reasons: why a linked worktree is considered disposable.
+const (
+	WorktreeReasonStale    = "stale registration"
+	WorktreeReasonOrphaned = "outside root"
+	WorktreeReasonMerged   = "branch merged"
+	WorktreeReasonGone     = "upstream gone"
+)
+
+// Keep reasons: why a linked worktree is never removed automatically.
+const (
+	WorktreeKeepMain     = "main worktree"
+	WorktreeKeepLocked   = "locked"
+	WorktreeKeepDetached = "detached HEAD"
+	WorktreeKeepDirty    = "uncommitted changes"
+	WorktreeKeepUnpushed = "unpushed commits"
+	WorktreeKeepActive   = "active"
+)
+
+const (
+	logFieldWorktree = "worktree"
+	logFieldReason   = "reason"
+	logFieldBranch   = "branch"
+)
+
+// Field keys emitted by `git worktree list --porcelain`.
+const (
+	worktreeFieldPath   = "worktree"
+	worktreeFieldHead   = "HEAD"
+	worktreeFieldBranch = "branch"
+)
+
+// Worktree describes a single entry of `git worktree list --porcelain`.
+type Worktree struct {
+	Path     string
+	Branch   string
+	Head     string
+	IsMain   bool
+	Bare     bool
+	Detached bool
+	Locked   bool
+	Prunable bool
+}
+
+// WorktreeCandidate is a classified worktree along with the repository it belongs to.
+type WorktreeCandidate struct {
+	Repo     string
+	RepoPath string
+	Worktree Worktree
+	Keep     bool
+	Reason   string
+}
+
+// WorktreePruneConfig holds all dependencies for a worktree cleanup operation.
+type WorktreePruneConfig struct {
+	RootDir   string
+	DryRun    bool
+	AssumeYes bool
+	Runner    GitRunner
+	Output    io.Writer
+	Input     io.Reader
+	Logger    logger.FieldLogger
+}
+
+func (c *WorktreePruneConfig) log() logger.FieldLogger {
+	if c.Logger == nil {
+		c.Logger = NewLogger(c.Output)
+	}
+	return c.Logger
+}
+
+//nolint:gochecknoglobals // read-only configuration lookup table
+var worktreeFieldSetters = map[string]func(w *Worktree, value string){
+	worktreeFieldHead:   func(w *Worktree, v string) { w.Head = v },
+	worktreeFieldBranch: func(w *Worktree, v string) { w.Branch = strings.TrimPrefix(v, "refs/heads/") },
+	"detached":          func(w *Worktree, _ string) { w.Detached = true },
+	"bare":              func(w *Worktree, _ string) { w.Bare = true },
+	"locked":            func(w *Worktree, _ string) { w.Locked = true },
+	"prunable":          func(w *Worktree, _ string) { w.Prunable = true },
+}
+
+// ParseWorktreeList parses the output of `git worktree list --porcelain`.
+// The first entry is always the main worktree.
+func ParseWorktreeList(output string) []Worktree {
+	var worktrees []Worktree
+	var current *Worktree
+
+	flush := func() {
+		if current != nil {
+			worktrees = append(worktrees, *current)
+			current = nil
+		}
+	}
+
+	for rawLine := range strings.SplitSeq(output, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			flush()
+			continue
+		}
+		key, value, _ := strings.Cut(line, " ")
+		if key == worktreeFieldPath {
+			flush()
+			current = &Worktree{Path: value, IsMain: len(worktrees) == 0}
+			continue
+		}
+		if setter, ok := worktreeFieldSetters[key]; ok && current != nil {
+			setter(current, value)
+		}
+	}
+	flush()
+
+	return worktrees
+}
+
+// worktreeEnv carries the per-repository facts that classification rules consult.
+type worktreeEnv struct {
+	rootDir string
+	merged  map[string]struct{}
+	gone    map[string]struct{}
+	runner  GitRunner
+}
+
+func (e worktreeEnv) isInsideRoot(w Worktree) bool {
+	rel, err := filepath.Rel(e.rootDir, w.Path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func (e worktreeEnv) isDirty(w Worktree) bool {
+	return e.runner.Output(w.Path, "status", "--porcelain") != ""
+}
+
+// isAhead reports whether the worktree branch holds commits its upstream does not.
+// A branch whose upstream was deleted has nothing to compare against, so it is not
+// treated as ahead: the "upstream gone" rule surfaces it for confirmation instead.
+func (e worktreeEnv) isAhead(w Worktree) bool {
+	if _, gone := e.gone[w.Branch]; gone {
+		return false
+	}
+	count := e.runner.Output(w.Path, "rev-list", "--count", "@{upstream}..HEAD")
+	return count != "" && count != "0"
+}
+
+func (e worktreeEnv) isMerged(w Worktree) bool {
+	_, ok := e.merged[w.Branch]
+	return ok
+}
+
+func (e worktreeEnv) isGone(w Worktree) bool {
+	_, ok := e.gone[w.Branch]
+	return ok
+}
+
+// worktreeRule pairs a classification reason with the predicate that detects it.
+type worktreeRule struct {
+	reason string
+	match  func(w Worktree, env worktreeEnv) bool
+}
+
+// worktreeGuardRules protect a worktree from automatic removal. They are evaluated
+// in order, before any removal rule, so losing work always wins over cleaning up.
+//
+//nolint:gochecknoglobals // read-only configuration lookup table
+var worktreeGuardRules = []worktreeRule{
+	{reason: WorktreeKeepLocked, match: func(w Worktree, _ worktreeEnv) bool { return w.Locked }},
+	{reason: WorktreeKeepDetached, match: func(w Worktree, _ worktreeEnv) bool { return w.Detached || w.Branch == "" }},
+	{reason: WorktreeKeepDirty, match: func(w Worktree, env worktreeEnv) bool { return env.isDirty(w) }},
+	{reason: WorktreeKeepUnpushed, match: func(w Worktree, env worktreeEnv) bool { return env.isAhead(w) }},
+}
+
+// worktreeRemovalRules mark a worktree as disposable, evaluated in order.
+//
+//nolint:gochecknoglobals // read-only configuration lookup table
+var worktreeRemovalRules = []worktreeRule{
+	{reason: WorktreeReasonOrphaned, match: func(w Worktree, env worktreeEnv) bool { return !env.isInsideRoot(w) }},
+	{reason: WorktreeReasonMerged, match: func(w Worktree, env worktreeEnv) bool { return env.isMerged(w) }},
+	{reason: WorktreeReasonGone, match: func(w Worktree, env worktreeEnv) bool { return env.isGone(w) }},
+}
+
+// classifyWorktree decides whether a worktree is disposable and records why.
+func classifyWorktree(w Worktree, env worktreeEnv) WorktreeCandidate {
+	candidate := WorktreeCandidate{Worktree: w}
+
+	if w.IsMain {
+		candidate.Keep, candidate.Reason = true, WorktreeKeepMain
+		return candidate
+	}
+
+	// A stale registration has no directory left on disk, so no guard can apply and
+	// dropping it only touches the parent repository's metadata.
+	if w.Prunable {
+		candidate.Reason = WorktreeReasonStale
+		return candidate
+	}
+
+	for _, guard := range worktreeGuardRules {
+		if guard.match(w, env) {
+			candidate.Keep, candidate.Reason = true, guard.reason
+			return candidate
+		}
+	}
+
+	for _, rule := range worktreeRemovalRules {
+		if rule.match(w, env) {
+			candidate.Reason = rule.reason
+			return candidate
+		}
+	}
+
+	candidate.Keep, candidate.Reason = true, WorktreeKeepActive
+	return candidate
+}
+
+// ListGoneBranches returns local branches whose upstream has been deleted on the remote.
+func ListGoneBranches(repoPath string, runner GitRunner) map[string]struct{} {
+	gone := make(map[string]struct{})
+	output := runner.Output(
+		repoPath, "for-each-ref", "--format=%(refname:short) %(upstream:track)", "refs/heads",
+	)
+	if output == "" {
+		return gone
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		name, track, found := strings.Cut(strings.TrimSpace(line), " ")
+		if !found || !strings.Contains(track, "[gone]") {
+			continue
+		}
+		gone[name] = struct{}{}
+	}
+	return gone
+}
+
+// ScanWorktrees classifies every worktree registered in a single repository.
+func ScanWorktrees(repoPath, rootDir string, runner GitRunner) []WorktreeCandidate {
+	worktrees := ParseWorktreeList(runner.Output(repoPath, "worktree", "list", "--porcelain"))
+	if len(worktrees) <= 1 {
+		return nil
+	}
+
+	name, err := filepath.Rel(rootDir, repoPath)
+	if err != nil {
+		name = repoPath
+	}
+
+	defaultBranch := DetectDefaultBranch(repoPath, runner)
+	env := worktreeEnv{
+		rootDir: rootDir,
+		merged:  toBranchSet(ListMergedBranches(repoPath, defaultBranch, runner)),
+		gone:    ListGoneBranches(repoPath, runner),
+		runner:  runner,
+	}
+
+	candidates := make([]WorktreeCandidate, 0, len(worktrees))
+	for _, w := range worktrees {
+		candidate := classifyWorktree(w, env)
+		candidate.Repo, candidate.RepoPath = name, repoPath
+		candidates = append(candidates, candidate)
+	}
+	return candidates
+}
+
+func toBranchSet(branches []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(branches))
+	for _, b := range branches {
+		set[b] = struct{}{}
+	}
+	return set
+}
+
+// ScanAllWorktrees classifies the worktrees of every repository in parallel,
+// preserving the repository order for deterministic reporting.
+func ScanAllWorktrees(repos []string, rootDir string, runner GitRunner) []WorktreeCandidate {
+	workers := runtime.NumCPU()
+	sem := make(chan struct{}, workers)
+	results := make([][]WorktreeCandidate, len(repos))
+	var wg sync.WaitGroup
+
+	for i, repoPath := range repos {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, path string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[idx] = ScanWorktrees(path, rootDir, runner)
+		}(i, repoPath)
+	}
+
+	wg.Wait()
+
+	var all []WorktreeCandidate
+	for _, r := range results {
+		all = append(all, r...)
+	}
+	return all
+}
+
+// FilterRemovableWorktrees returns only the candidates marked for removal.
+func FilterRemovableWorktrees(candidates []WorktreeCandidate) []WorktreeCandidate {
+	var removable []WorktreeCandidate
+	for _, c := range candidates {
+		if !c.Keep {
+			removable = append(removable, c)
+		}
+	}
+	return removable
+}
+
+// RemoveWorktree drops a worktree through git so the parent repository's metadata
+// stays consistent. Stale registrations are cleared with `worktree prune`; live ones
+// go through `worktree remove`, which refuses to discard uncommitted work.
+func RemoveWorktree(c WorktreeCandidate, runner GitRunner) error {
+	if c.Reason == WorktreeReasonStale {
+		if err := runner.Run(c.RepoPath, "worktree", "prune"); err != nil {
+			return fmt.Errorf("worktree prune: %w", err)
+		}
+		return nil
+	}
+	if err := runner.Run(c.RepoPath, "worktree", "remove", c.Worktree.Path); err != nil {
+		return fmt.Errorf("worktree remove: %w", err)
+	}
+	return nil
+}
+
+// RunWorktreeList reports every worktree found under rootDir with its classification.
+func RunWorktreeList(rootDir string, runner GitRunner, output io.Writer) error {
+	log := NewLogger(output)
+
+	repos := FindAllRepos(rootDir)
+	if len(repos) == 0 {
+		log.WithField("dir", rootDir).Warn("no git repositories found")
+		return nil
+	}
+
+	candidates := ScanAllWorktrees(repos, rootDir, runner)
+	linked := 0
+	for _, c := range candidates {
+		if c.Worktree.IsMain {
+			continue
+		}
+		linked++
+		log.WithFields(logger.Fields{
+			logFieldRepo:     c.Repo,
+			logFieldWorktree: c.Worktree.Path,
+			logFieldBranch:   c.Worktree.Branch,
+			logFieldReason:   c.Reason,
+			"removable":      !c.Keep,
+		}).Info("worktree")
+	}
+
+	log.WithFields(logger.Fields{
+		"repos":     len(repos),
+		"worktrees": linked,
+		"removable": len(FilterRemovableWorktrees(candidates)),
+	}).Info("summary")
+	return nil
+}
+
+// RunWorktreePrune removes disposable worktrees under rootDir. Scanning runs in
+// parallel; removal is sequential so each worktree can be confirmed interactively.
+func RunWorktreePrune(cfg WorktreePruneConfig) error {
+	log := cfg.log()
+
+	repos := FindAllRepos(cfg.RootDir)
+	if len(repos) == 0 {
+		log.WithField("dir", cfg.RootDir).Warn("no git repositories found")
+		return nil
+	}
+
+	log.WithField("count", len(repos)).Info("scanning repositories for worktrees")
+	if cfg.DryRun {
+		log.Info("dry-run mode enabled")
+	}
+
+	candidates := ScanAllWorktrees(repos, cfg.RootDir, cfg.Runner)
+	LogGuardedWorktrees(candidates, log)
+
+	removable := FilterRemovableWorktrees(candidates)
+	if len(removable) == 0 {
+		log.Info("no disposable worktrees found")
+		return nil
+	}
+
+	removed, kept, failed := ProcessWorktreeRemovals(removable, cfg, log)
+	log.WithFields(logger.Fields{
+		"removed":          removed,
+		"kept":             kept,
+		mirrorStatusFailed: failed,
+	}).Info("summary")
+	return nil
+}
+
+// LogGuardedWorktrees reports worktrees that were protected for a notable reason,
+// so a dirty or locked worktree never disappears silently from the report.
+func LogGuardedWorktrees(candidates []WorktreeCandidate, log logger.FieldLogger) {
+	for _, c := range candidates {
+		if !c.Keep || c.Reason == WorktreeKeepMain || c.Reason == WorktreeKeepActive {
+			continue
+		}
+		log.WithFields(logger.Fields{
+			logFieldRepo:     c.Repo,
+			logFieldWorktree: c.Worktree.Path,
+			logFieldReason:   c.Reason,
+		}).Info("kept worktree")
+	}
+}
+
+// ProcessWorktreeRemovals walks the removal candidates and applies the configured
+// policy to each one. Returns the removed, kept, and failed counts.
+func ProcessWorktreeRemovals(
+	removable []WorktreeCandidate, cfg WorktreePruneConfig, log logger.FieldLogger,
+) (int, int, int) {
+	isInteractive := isTerminal(cfg.Input)
+	scanner := bufio.NewScanner(cfg.Input)
+	removed, kept, failed := 0, 0, 0
+
+	for _, c := range removable {
+		entry := log.WithFields(logger.Fields{
+			logFieldRepo:     c.Repo,
+			logFieldWorktree: c.Worktree.Path,
+			logFieldBranch:   c.Worktree.Branch,
+			logFieldReason:   c.Reason,
+		})
+
+		switch {
+		case cfg.DryRun:
+			entry.Info("would remove worktree")
+			kept++
+		case cfg.AssumeYes:
+			removed, failed = applyWorktreeRemoval(c, cfg.Runner, entry, removed, failed)
+		case !isInteractive:
+			entry.Warn("disposable worktree (kept, non-interactive)")
+			kept++
+		case PromptRemoveWorktree(c, scanner, cfg.Output):
+			removed, failed = applyWorktreeRemoval(c, cfg.Runner, entry, removed, failed)
+		default:
+			entry.Info("kept worktree")
+			kept++
+		}
+	}
+
+	return removed, kept, failed
+}
+
+func applyWorktreeRemoval(
+	c WorktreeCandidate, runner GitRunner, entry logger.FieldLogger, removed, failed int,
+) (int, int) {
+	if err := RemoveWorktree(c, runner); err != nil {
+		entry.WithError(err).Error("could not remove worktree")
+		return removed, failed + 1
+	}
+	entry.Info("removed worktree")
+	return removed + 1, failed
+}
+
+// PromptRemoveWorktree asks the user to confirm removal of a single worktree.
+// The scanner is shared across prompts so buffered input is not discarded between them.
+func PromptRemoveWorktree(c WorktreeCandidate, scanner *bufio.Scanner, output io.Writer) bool {
+	branch := c.Worktree.Branch
+	if branch == "" {
+		branch = c.Worktree.Head
+	}
+	fmt.Fprintf(output, "[dev] worktree \"%s\" of \"%s\" (branch %s) is %s. Remove? [y/N] ",
+		c.Worktree.Path, c.Repo, branch, c.Reason)
+	return scanner.Scan() && strings.EqualFold(strings.TrimSpace(scanner.Text()), "y")
+}

--- a/internal/repo/worktree_test.go
+++ b/internal/repo/worktree_test.go
@@ -1,0 +1,778 @@
+package repo_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/dev-toolkit/internal/repo"
+	"github.com/rios0rios0/dev-toolkit/internal/testutil/doubles"
+)
+
+const goneRefFormat = "--format=%(refname:short) %(upstream:track)"
+
+// worktreeEntry renders one `git worktree list --porcelain` record.
+func worktreeEntry(path, branch string, extra ...string) string {
+	lines := []string{"worktree " + path, "HEAD abc123"}
+	if branch == "" {
+		lines = append(lines, "detached")
+	} else {
+		lines = append(lines, "branch refs/heads/"+branch)
+	}
+	lines = append(lines, extra...)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// worktreeRunner builds a stub answering the commands ScanWorktrees issues.
+func worktreeRunner(porcelain string) *doubles.GitRunnerStub {
+	return doubles.NewGitRunnerStub().
+		WithOutput([]string{"worktree", "list", "--porcelain"}, porcelain).
+		WithOutput([]string{"symbolic-ref", "refs/remotes/origin/HEAD"}, "refs/remotes/origin/main").
+		WithOutput([]string{"branch", "--merged", "main"}, "* main")
+}
+
+func TestParseWorktreeList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should mark the first entry as the main worktree", func(t *testing.T) {
+		t.Parallel()
+		// given
+		output := worktreeEntry("/root/repo", "main") + "\n" + worktreeEntry("/root/repo-wt", "feat/x")
+
+		// when
+		worktrees := repo.ParseWorktreeList(output)
+
+		// then
+		require.Len(t, worktrees, 2)
+		assert.True(t, worktrees[0].IsMain)
+		assert.False(t, worktrees[1].IsMain)
+	})
+
+	t.Run("should strip the refs/heads prefix from branch names", func(t *testing.T) {
+		t.Parallel()
+		// given
+		output := worktreeEntry("/root/repo", "feat/audit-log")
+
+		// when
+		worktrees := repo.ParseWorktreeList(output)
+
+		// then
+		require.Len(t, worktrees, 1)
+		assert.Equal(t, "feat/audit-log", worktrees[0].Branch)
+		assert.Equal(t, "abc123", worktrees[0].Head)
+	})
+
+	t.Run("should flag detached, locked, prunable and bare entries", func(t *testing.T) {
+		t.Parallel()
+		// given
+		output := worktreeEntry("/root/repo", "main", "bare") + "\n" +
+			worktreeEntry("/root/wt-detached", "") + "\n" +
+			worktreeEntry("/root/wt-locked", "feat/x", "locked because reasons") + "\n" +
+			worktreeEntry("/root/wt-gone", "feat/y", "prunable gitdir file points to non-existent location")
+
+		// when
+		worktrees := repo.ParseWorktreeList(output)
+
+		// then
+		require.Len(t, worktrees, 4)
+		assert.True(t, worktrees[0].Bare)
+		assert.True(t, worktrees[1].Detached)
+		assert.True(t, worktrees[2].Locked)
+		assert.True(t, worktrees[3].Prunable)
+	})
+
+	t.Run("should return nothing when output is empty", func(t *testing.T) {
+		t.Parallel()
+		// given
+		output := ""
+
+		// when
+		worktrees := repo.ParseWorktreeList(output)
+
+		// then
+		assert.Empty(t, worktrees)
+	})
+
+	t.Run("should tolerate a missing blank line between records", func(t *testing.T) {
+		t.Parallel()
+		// given
+		output := "worktree /root/repo\nHEAD abc\nworktree /root/repo-wt\nHEAD def\n"
+
+		// when
+		worktrees := repo.ParseWorktreeList(output)
+
+		// then
+		require.Len(t, worktrees, 2)
+		assert.Equal(t, "/root/repo", worktrees[0].Path)
+		assert.Equal(t, "/root/repo-wt", worktrees[1].Path)
+	})
+}
+
+func TestScanWorktrees(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return nothing when the repo has only its main worktree", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(worktreeEntry("/root/repo", "main"))
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		assert.Empty(t, candidates)
+	})
+
+	t.Run("should always keep the main worktree", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main") + "\n" + worktreeEntry("/root/repo-wt", "feat/x"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[0].Keep)
+		assert.Equal(t, repo.WorktreeKeepMain, candidates[0].Reason)
+		assert.Equal(t, "repo", candidates[0].Repo)
+	})
+
+	t.Run("should mark a prunable registration as stale", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main") + "\n" +
+				worktreeEntry("/root/repo-wt", "feat/x", "prunable gitdir file points to non-existent location"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonStale, candidates[1].Reason)
+	})
+
+	t.Run("should mark a worktree living outside the root as orphaned", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main") + "\n" + worktreeEntry("/tmp/scratch/wt-stray", "feat/x"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonOrphaned, candidates[1].Reason)
+	})
+
+	t.Run("should mark a worktree whose branch is merged", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/done"),
+		).WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonMerged, candidates[1].Reason)
+	})
+
+	t.Run("should mark a worktree whose upstream was deleted", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/shipped"),
+		).WithOutput(
+			[]string{"for-each-ref", goneRefFormat, "refs/heads"},
+			"main [behind 1]\nfeat/shipped [gone]",
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonGone, candidates[1].Reason)
+	})
+
+	t.Run("should keep an active worktree that matches no removal rule", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main") + "\n" + worktreeEntry("/root/repo-wt", "feat/wip"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepActive, candidates[1].Reason)
+	})
+
+	t.Run("should keep a locked worktree even when its branch is merged", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+
+				worktreeEntry("/root/repo-wt", "feat/done", "locked in use"),
+		).WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepLocked, candidates[1].Reason)
+	})
+
+	t.Run("should keep a dirty worktree even when its branch is merged", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/done"),
+		).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithOutputForDir("/root/repo-wt", []string{"status", "--porcelain"}, " M internal/repo/clone.go")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepDirty, candidates[1].Reason)
+	})
+
+	t.Run("should keep a worktree holding unpushed commits", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/done"),
+		).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithOutputForDir("/root/repo-wt", []string{"rev-list", "--count", "@{upstream}..HEAD"}, "3")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepUnpushed, candidates[1].Reason)
+	})
+
+	t.Run("should not treat an in-sync branch as holding unpushed commits", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/done"),
+		).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithOutputForDir("/root/repo-wt", []string{"rev-list", "--count", "@{upstream}..HEAD"}, "0")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonMerged, candidates[1].Reason)
+	})
+
+	t.Run("should keep a detached worktree", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main") + "\n" + worktreeEntry("/root/repo-wt", ""),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepDetached, candidates[1].Reason)
+	})
+
+	t.Run("should not treat a gone branch as holding unpushed commits", func(t *testing.T) {
+		t.Parallel()
+		// given a gone upstream makes `rev-list @{upstream}..HEAD` meaningless
+		runner := worktreeRunner(
+			worktreeEntry("/root/repo", "main")+"\n"+worktreeEntry("/root/repo-wt", "feat/shipped"),
+		).
+			WithOutput([]string{"for-each-ref", goneRefFormat, "refs/heads"}, "feat/shipped [gone]").
+			WithOutputForDir("/root/repo-wt", []string{"rev-list", "--count", "@{upstream}..HEAD"}, "7")
+
+		// when
+		candidates := repo.ScanWorktrees("/root/repo", "/root", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonGone, candidates[1].Reason)
+	})
+}
+
+func TestListGoneBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return only branches whose upstream is gone", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := doubles.NewGitRunnerStub().WithOutput(
+			[]string{"for-each-ref", goneRefFormat, "refs/heads"},
+			"main \nfeat/a [gone]\nfeat/b [ahead 2]\nfeat/c [gone]",
+		)
+
+		// when
+		gone := repo.ListGoneBranches("/root/repo", runner)
+
+		// then
+		assert.Len(t, gone, 2)
+		assert.Contains(t, gone, "feat/a")
+		assert.Contains(t, gone, "feat/c")
+	})
+
+	t.Run("should return an empty set when there is no output", func(t *testing.T) {
+		t.Parallel()
+		// given
+		runner := doubles.NewGitRunnerStub()
+
+		// when
+		gone := repo.ListGoneBranches("/root/repo", runner)
+
+		// then
+		assert.Empty(t, gone)
+	})
+}
+
+func TestFilterRemovableWorktrees(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return only candidates not marked to keep", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidates := []repo.WorktreeCandidate{
+			{Repo: "a", Keep: true, Reason: repo.WorktreeKeepMain},
+			{Repo: "b", Reason: repo.WorktreeReasonMerged},
+			{Repo: "c", Keep: true, Reason: repo.WorktreeKeepDirty},
+			{Repo: "d", Reason: repo.WorktreeReasonStale},
+		}
+
+		// when
+		removable := repo.FilterRemovableWorktrees(candidates)
+
+		// then
+		require.Len(t, removable, 2)
+		assert.Equal(t, "b", removable[0].Repo)
+		assert.Equal(t, "d", removable[1].Repo)
+	})
+
+	t.Run("should return nothing when every candidate is kept", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidates := []repo.WorktreeCandidate{{Repo: "a", Keep: true}}
+
+		// when
+		removable := repo.FilterRemovableWorktrees(candidates)
+
+		// then
+		assert.Empty(t, removable)
+	})
+}
+
+func TestRemoveWorktree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should drop a stale registration with worktree prune", func(t *testing.T) {
+		t.Parallel()
+		// given a runner that fails only on `worktree prune`
+		candidate := repo.WorktreeCandidate{
+			RepoPath: "/root/repo",
+			Worktree: repo.Worktree{Path: "/root/repo-wt"},
+			Reason:   repo.WorktreeReasonStale,
+		}
+		runner := doubles.NewGitRunnerStub().
+			WithRunError([]string{"worktree", "prune"}, errors.New("boom"))
+
+		// when
+		err := repo.RemoveWorktree(candidate, runner)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "worktree prune")
+	})
+
+	t.Run("should not call worktree remove for a stale registration", func(t *testing.T) {
+		t.Parallel()
+		// given a runner that fails only on `worktree remove`
+		candidate := repo.WorktreeCandidate{
+			RepoPath: "/root/repo",
+			Worktree: repo.Worktree{Path: "/root/repo-wt"},
+			Reason:   repo.WorktreeReasonStale,
+		}
+		runner := doubles.NewGitRunnerStub().
+			WithRunError([]string{"worktree", "remove", "/root/repo-wt"}, errors.New("boom"))
+
+		// when
+		err := repo.RemoveWorktree(candidate, runner)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("should remove a live worktree through git", func(t *testing.T) {
+		t.Parallel()
+		// given a runner that fails only on the exact `worktree remove <path>` call
+		candidate := repo.WorktreeCandidate{
+			RepoPath: "/root/repo",
+			Worktree: repo.Worktree{Path: "/root/repo-wt"},
+			Reason:   repo.WorktreeReasonMerged,
+		}
+		runner := doubles.NewGitRunnerStub().
+			WithRunError([]string{"worktree", "remove", "/root/repo-wt"}, errors.New("contains modified files"))
+
+		// when
+		err := repo.RemoveWorktree(candidate, runner)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "worktree remove")
+		assert.Contains(t, err.Error(), "contains modified files")
+	})
+
+	t.Run("should succeed when git accepts the removal", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidate := repo.WorktreeCandidate{
+			RepoPath: "/root/repo",
+			Worktree: repo.Worktree{Path: "/root/repo-wt"},
+			Reason:   repo.WorktreeReasonMerged,
+		}
+		runner := doubles.NewGitRunnerStub()
+
+		// when
+		err := repo.RemoveWorktree(candidate, runner)
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func TestPromptRemoveWorktree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should confirm when the user answers y", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidate := repo.WorktreeCandidate{
+			Repo:     "repo",
+			Worktree: repo.Worktree{Path: "/root/repo-wt", Branch: "feat/x"},
+			Reason:   repo.WorktreeReasonMerged,
+		}
+		scanner := bufio.NewScanner(strings.NewReader("y\n"))
+		var buf bytes.Buffer
+
+		// when
+		confirmed := repo.PromptRemoveWorktree(candidate, scanner, &buf)
+
+		// then
+		assert.True(t, confirmed)
+		assert.Contains(t, buf.String(), "/root/repo-wt")
+		assert.Contains(t, buf.String(), repo.WorktreeReasonMerged)
+	})
+
+	t.Run("should decline when the user answers n", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidate := repo.WorktreeCandidate{Worktree: repo.Worktree{Path: "/root/repo-wt", Branch: "feat/x"}}
+		scanner := bufio.NewScanner(strings.NewReader("n\n"))
+		var buf bytes.Buffer
+
+		// when
+		confirmed := repo.PromptRemoveWorktree(candidate, scanner, &buf)
+
+		// then
+		assert.False(t, confirmed)
+	})
+
+	t.Run("should read one answer per prompt from a shared scanner", func(t *testing.T) {
+		t.Parallel()
+		// given
+		first := repo.WorktreeCandidate{Worktree: repo.Worktree{Path: "/root/wt-a", Branch: "feat/a"}}
+		second := repo.WorktreeCandidate{Worktree: repo.Worktree{Path: "/root/wt-b", Branch: "feat/b"}}
+		scanner := bufio.NewScanner(strings.NewReader("n\ny\n"))
+		var buf bytes.Buffer
+
+		// when
+		firstAnswer := repo.PromptRemoveWorktree(first, scanner, &buf)
+		secondAnswer := repo.PromptRemoveWorktree(second, scanner, &buf)
+
+		// then
+		assert.False(t, firstAnswer)
+		assert.True(t, secondAnswer)
+	})
+
+	t.Run("should fall back to the head when the worktree is detached", func(t *testing.T) {
+		t.Parallel()
+		// given
+		candidate := repo.WorktreeCandidate{Worktree: repo.Worktree{Path: "/root/wt", Head: "abc123"}}
+		scanner := bufio.NewScanner(strings.NewReader("\n"))
+		var buf bytes.Buffer
+
+		// when
+		repo.PromptRemoveWorktree(candidate, scanner, &buf)
+
+		// then
+		assert.Contains(t, buf.String(), "abc123")
+	})
+}
+
+func TestRunWorktreePrune(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should warn when no repositories exist", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{
+			RootDir: t.TempDir(),
+			Runner:  doubles.NewGitRunnerStub(),
+			Output:  &buf,
+		}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "no git repositories found")
+	})
+
+	t.Run("should report when nothing is disposable", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{
+			RootDir: root,
+			Runner:  worktreeRunner(worktreeEntry(root+"/repo-a", "main")),
+			Output:  &buf,
+		}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "no disposable worktrees found")
+	})
+
+	t.Run("should report would-remove in dry-run mode without removing", func(t *testing.T) {
+		t.Parallel()
+		// given a runner that errors if any removal is attempted
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithRunError([]string{"worktree", "remove", root + "/repo-a-wt"}, errors.New("must not run"))
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{RootDir: root, DryRun: true, Runner: runner, Output: &buf}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "dry-run mode enabled")
+		assert.Contains(t, output, "would remove worktree")
+		assert.Contains(t, output, "removed=0")
+	})
+
+	t.Run("should remove disposable worktrees when confirmation is assumed", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done")
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{RootDir: root, AssumeYes: true, Runner: runner, Output: &buf}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "removed worktree")
+		assert.Contains(t, output, "removed=1")
+		assert.Contains(t, output, "failed=0")
+	})
+
+	t.Run("should count a failed removal instead of aborting", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithRunError(
+				[]string{"worktree", "remove", root + "/repo-a-wt"},
+				errors.New("contains modified files"),
+			)
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{RootDir: root, AssumeYes: true, Runner: runner, Output: &buf}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "could not remove worktree")
+		assert.Contains(t, output, "failed=1")
+		assert.Contains(t, output, "removed=0")
+	})
+
+	t.Run("should keep disposable worktrees when input is not a terminal", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithRunError([]string{"worktree", "remove", root + "/repo-a-wt"}, errors.New("must not run"))
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{
+			RootDir: root,
+			Runner:  runner,
+			Output:  &buf,
+			Input:   strings.NewReader("y\n"),
+		}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "non-interactive")
+		assert.Contains(t, output, "removed=0")
+		assert.Contains(t, output, "kept=1")
+	})
+
+	t.Run("should report a protected worktree so it does not disappear silently", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done").
+			WithOutputForDir(root+"/repo-a-wt", []string{"status", "--porcelain"}, " M main.go")
+		var buf bytes.Buffer
+		cfg := repo.WorktreePruneConfig{RootDir: root, AssumeYes: true, Runner: runner, Output: &buf}
+
+		// when
+		err := repo.RunWorktreePrune(cfg)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "kept worktree")
+		assert.Contains(t, output, repo.WorktreeKeepDirty)
+		assert.Contains(t, output, "no disposable worktrees found")
+	})
+}
+
+func TestRunWorktreeList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should warn when no repositories exist", func(t *testing.T) {
+		t.Parallel()
+		// given
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunWorktreeList(t.TempDir(), doubles.NewGitRunnerStub(), &buf)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "no git repositories found")
+	})
+
+	t.Run("should list linked worktrees with their classification", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		porcelain := worktreeEntry(root+"/repo-a", "main") + "\n" +
+			worktreeEntry(root+"/repo-a-wt", "feat/done")
+		runner := worktreeRunner(porcelain).
+			WithOutput([]string{"branch", "--merged", "main"}, "* main\n+ feat/done")
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunWorktreeList(root, runner, &buf)
+
+		// then
+		require.NoError(t, err)
+		output := buf.String()
+		assert.Contains(t, output, "repo-a-wt")
+		assert.Contains(t, output, repo.WorktreeReasonMerged)
+		assert.Contains(t, output, "worktrees=1")
+		assert.Contains(t, output, "removable=1")
+	})
+
+	t.Run("should not list the main worktree as an entry", func(t *testing.T) {
+		t.Parallel()
+		// given
+		root := t.TempDir()
+		createGitRepo(t, root+"/repo-a")
+		runner := worktreeRunner(
+			worktreeEntry(root+"/repo-a", "main") + "\n" + worktreeEntry(root+"/repo-a-wt", "feat/x"),
+		)
+		var buf bytes.Buffer
+
+		// when
+		err := repo.RunWorktreeList(root, runner, &buf)
+
+		// then
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "worktrees=1")
+	})
+}

--- a/internal/repo/worktree_test.go
+++ b/internal/repo/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -211,6 +212,42 @@ func TestScanWorktrees(t *testing.T) {
 		require.Len(t, candidates, 2)
 		assert.False(t, candidates[1].Keep)
 		assert.Equal(t, repo.WorktreeReasonGone, candidates[1].Reason)
+	})
+
+	t.Run("should not treat a worktree as orphaned when the root is relative", func(t *testing.T) {
+		t.Parallel()
+		// given git always reports absolute worktree paths, while the root may be relative
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		runner := worktreeRunner(
+			worktreeEntry(cwd+"/repo", "main") + "\n" + worktreeEntry(cwd+"/repo-wt", "feat/wip"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("repo", ".", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.True(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeKeepActive, candidates[1].Reason)
+	})
+
+	t.Run("should still flag a worktree outside a relative root as orphaned", func(t *testing.T) {
+		t.Parallel()
+		// given
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		runner := worktreeRunner(
+			worktreeEntry(cwd+"/repo", "main") + "\n" + worktreeEntry("/tmp/scratch/wt-stray", "feat/wip"),
+		)
+
+		// when
+		candidates := repo.ScanWorktrees("repo", ".", runner)
+
+		// then
+		require.Len(t, candidates, 2)
+		assert.False(t, candidates[1].Keep)
+		assert.Equal(t, repo.WorktreeReasonOrphaned, candidates[1].Reason)
 	})
 
 	t.Run("should keep an active worktree that matches no removal rule", func(t *testing.T) {

--- a/internal/testutil/doubles/git_runner_stub.go
+++ b/internal/testutil/doubles/git_runner_stub.go
@@ -39,6 +39,20 @@ func (s *GitRunnerStub) WithOutput(args []string, output string) *GitRunnerStub 
 	return s
 }
 
+// WithOutputForDir configures output for a command only when it runs in a specific
+// directory, so callers that fan the same command across sibling checkouts (e.g.
+// worktrees) can be given per-directory answers.
+func (s *GitRunnerStub) WithOutputForDir(dir string, args []string, output string) *GitRunnerStub {
+	prev := s.OutputFunc
+	s.OutputFunc = func(d string, a ...string) string {
+		if d == dir && matchArgs(args, a) {
+			return output
+		}
+		return prev(d, a...)
+	}
+	return s
+}
+
 func (s *GitRunnerStub) Run(dir string, args ...string) error {
 	return s.RunFunc(dir, args...)
 }


### PR DESCRIPTION
## Problem

Linked Git worktrees are invisible to every repository workflow. A worktree stores `.git` as a **file** (`gitdir: ...`), but all three scanners require it to be a directory:

- `internal/repo/scanner.go:28` — `os.Stat(gitDir); ... && info.IsDir()` (flat scan)
- `internal/repo/scanner.go:62` — same check (nested scan, used by Azure DevOps)
- `internal/repo/scanner.go:76` — `info.IsDir() && info.Name() == ".git"` (`FindAllRepos`)

So worktrees never enter `localRepos`, never appear in the `clone` diff, and are silently skipped by `sync`, `prune`, `fork-sync`, `mirror`, `failover`, and `restore` as well.

## Why they are not simply added to the clone diff

Making the scanners accept `.git` files would put worktrees into `extra`, where `PromptDeleteExtra` would `os.RemoveAll` them on a single `y`. That would:

1. **Corrupt the parent repo** — leave a dangling `<parent>/.git/worktrees/<name>` registration, so a later `git worktree add` with that name fails.
2. **Destroy uncommitted work** — there is no dirty check on that path.
3. **Be semantically wrong** — a worktree is an extra checkout of a repo that *does* exist on the remote, not a repo missing from it. A worktree whose name collides with a real remote repo would also silently mask it.

Worktrees therefore stay out of the remote-vs-local diff and get dedicated commands.

## Changes

| Command | Behavior |
|---|---|
| `dev repo worktree list [root-dir]` | Reports every linked worktree with the reason it is disposable or protected |
| `dev repo worktree prune [root-dir]` | Removes disposable worktrees; `--dry-run` and `--yes` supported |
| `dev repo clone ... --prune-worktrees` | Runs the same cleanup pass after the clone workflow |

**Removal reasons:** stale registration (directory gone), outside root, branch merged into the default branch, upstream branch deleted on the remote.

**Guards — never removed automatically:** the main worktree, locked, detached HEAD, uncommitted changes, unpushed commits. Guards are evaluated *before* removal rules, so preserving work always wins.

Removal goes through `git worktree remove` / `git worktree prune`, never `os.RemoveAll`, so the parent repository's metadata stays consistent and git's own dirty check acts as a second safety net. Scanning is parallel; removal is sequential so each one can be confirmed interactively (single shared `bufio.Scanner`, so buffered input is not dropped between prompts).

Classification uses ordered rule tables (`worktreeGuardRules`, `worktreeRemovalRules`) rather than branching, consistent with the repo's no-switch/case convention.

**Note on ordering:** run `worktree prune` before `repo prune` — `git branch -d` fails on a branch checked out in another worktree, so removing the worktree first makes that branch deletable.

## Validation

Verified against a real Azure DevOps workspace with 61 repos and 17 linked worktrees:

```
summary removable=4 repos=61 worktrees=17
```

- The 4 flagged were abandoned worktrees living in `/tmp` scratchpad directories (`outside root`).
- 3 dirty worktrees were correctly protected with `reason="uncommitted changes"`.
- The remaining 10 were correctly left as `active`.

`make build`, `make lint` (0 issues), `make test`, and `make sast` (Semgrep 0 findings, Gitleaks no leaks) all pass. 43 new BDD test cases; `worktree.go` is at 100% coverage except `isInsideRoot` (75%) and `ProcessWorktreeRemovals` (80%, the interactive-TTY branch, which the existing `HandleExtraRepos` cannot cover either).

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
