### PR TITLE
chore(deps): bumped `langforge` to `v1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go version to `1.26.6` and updated all module dependencies
+- changed `langforge` to `v1.0.0`, which makes Dart/Flutter projects detectable by every `dev project` command -- this crosses a MAJOR boundary, but both breaking changes (the per-ecosystem `Provider` structs replaced by `repositories.CompositeProvider`, and `javagradle.RuntimeManager`/`javamaven.RuntimeManager` merged into a shared `java.RuntimeManager`) only affect callers naming those concrete types, which this project never did
 
 ## [0.9.4] - 2026-08-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,5 +150,5 @@ internal/
 
 - **gitforge** -- Multi-provider Git hosting abstractions (GitHub, Azure DevOps, GitLab, Codeberg)
 - **go-github** -- GitHub API client (used by `ForkResolver` to get fork parent info)
-- **langforge** -- Language detection, version management, and runtime information (Go, Node, Python, Java, C#, Terraform)
+- **langforge** -- Language detection, version management, and runtime information (Go, Dart, Node, Python, Java, C#, Ruby, Terraform)
 - **cliforge** -- Self-update mechanism and automatic version check on startup

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v66 v66.0.0
 	github.com/rios0rios0/cliforge v0.3.14
 	github.com/rios0rios0/gitforge v1.0.0
-	github.com/rios0rios0/langforge v0.6.11
+	github.com/rios0rios0/langforge v1.0.0
 	github.com/sirupsen/logrus v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/rios0rios0/cliforge v0.3.14 h1:g3hSNyhLFgemWWgO+zzCQvbBprEiIuN2ARhV3j
 github.com/rios0rios0/cliforge v0.3.14/go.mod h1:6+3AwCsoJlSDaw7pu2Qe8S5Jw/059ZBMyZuQVcyFps8=
 github.com/rios0rios0/gitforge v1.0.0 h1:9zptCSKlPWQ+hE6olhKI6Rp8axo1Tn+r4f97XTRFqfY=
 github.com/rios0rios0/gitforge v1.0.0/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
-github.com/rios0rios0/langforge v0.6.11 h1:40Hs4VsOCx3vbl9WtOay5LfnDrG8d3VJ+Ivty8BHBnM=
-github.com/rios0rios0/langforge v0.6.11/go.mod h1:BcPZELX3TWdrPI7MzpevpNwXfwRJAsgrEZ+J5BLTq+s=
+github.com/rios0rios0/langforge v1.0.0 h1:J+5NdV30dDq1LW9jdDQKCeoAuEuUreocosvWbnbu8qQ=
+github.com/rios0rios0/langforge v1.0.0/go.mod h1:TabMEVXALv2Vvj4Er/4u9mf2SAmzv0xjkB1TxFA7SPo=
 github.com/rios0rios0/testkit v0.2.6 h1:JtHkUwxrO3Uog5xYhZTVmdbrjyHEz36Vre3a2SR4yY8=
 github.com/rios0rios0/testkit v0.2.6/go.mod h1:dsQ2xX7nMAOkquTgakoA2/Z2sMBuBkCSEyLZMwpXU/Q=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## Why

`rios0rios0/langforge` released `v1.0.0`. This repository was pinned to `v0.6.11`, so the bump crosses a MAJOR boundary and deserves more than an automated dependency PR.

What it buys: **v1.0.0 adds a Dart/Flutter provider** to the default registry. Because `dev project` resolves everything through `langforge`'s registry, Dart/Flutter repositories become detectable by `info`, `use`, `start`, `build`, `lint`, `test` and `stop` with no code change here. Verified end-to-end against a scratch `pubspec.yaml`:

```
$ dev project info <dart-project>
[dev] language:        dart
[dev] SDK:             Dart
[dev] version manager: fvm
[dev] start command:   dart run
[dev] lint commands:   dart analyze
[dev] build commands:  dart pub get
```

## Why the breaking changes do not affect this repository

`v1.0.0` documents two breaking changes, and neither reaches this codebase:

1. **The nine per-ecosystem `Provider` structs were removed**, replaced by `repositories.CompositeProvider`. Only code naming a concrete type (`golang.Provider`, `dart.Provider`, …) breaks. This repository names none of them.
2. **`javagradle.RuntimeManager` and `javamaven.RuntimeManager` were removed** in favour of a shared `java.RuntimeManager`. Again, neither type is referenced here.

`langforge` is used in exactly one file, `internal/project/detect.go`, and only through these symbols — all of which survive `v1.0.0` unchanged:

- `registry.NewDefaultRegistry()`
- `(*registry.LanguageRegistry).Detect(repoPath)`
- the `repositories.LanguageProviderFull` interface (via a type assertion)

`go build ./...` and the full test suite pass with no source changes.

## One latent hazard, checked and contained

`CompositeProvider` embeds *interfaces* rather than implementing the ports directly, so `*CompositeProvider` now **always** satisfies `LanguageProviderFull`. The type assertion in `detect.go` can therefore no longer fail, where previously a provider lacking a `RuntimeManager` would have failed it. langforge's own doc comment is explicit that this is by design:

> A language that implements only some of the ports leaves the rest nil, and the composite still satisfies the narrower interface its callers ask for. Only the ports it was given may be called.

So in the general case, a partially-populated composite would now pass the assertion and nil-panic on the first port call instead of being skipped. **It does not matter here**, for two independent reasons:

1. **The assertion is not used as a signal.** The `if full, ok := ...` block only *populates optional fields*; there is no `else` branch and no behaviour keyed on failure. A failed assertion previously just left `SDKName`, `LintCommands`, etc. empty, which the display path already renders as `(none)`.
2. **A partial provider cannot reach this code.** All nine providers in `NewDefaultRegistry()` populate all seven ports explicitly — verified by reading every `NewProvider()` in `v1.0.0`. And `DefaultLanguageDetector.registry` is an unexported field set only by `NewDefaultLanguageDetector()` to `NewDefaultRegistry()`; there is no setter and no injected registry, so a third-party partial provider cannot be introduced from this side.

Behaviour is therefore unchanged today. Worth knowing if `detect.go` ever gains an injectable registry — at that point the assertion would need a nil-port check to stay safe.

## Dependency diff

`go mod tidy` moved nothing else. The complete change:

```diff
-github.com/rios0rios0/langforge v0.6.11
+github.com/rios0rios0/langforge v1.0.0
```

plus the two corresponding `go.sum` hash lines. No other dependency, direct or indirect, changed.

## Validation

| Gate | Result |
|------|--------|
| `make lint` | 0 issues (79 linters) |
| `make test` | pass, unit + integration, 73.7% coverage |
| `make sast` | pass — CodeQL, Semgrep (0 findings), Trivy (0 misconfigs), Hadolint (n/a), Gitleaks (no leaks, **both** passes) |
| `make build` + smoke | `dev project info .` renders full Go metadata; Dart project detected correctly |

## Docs

`CLAUDE.md`'s langforge ecosystem list gained `Dart`. It was also missing `Ruby`, which `v0.6.11` already shipped — corrected on the same line. `README.md` and `.github/copilot-instructions.md` describe langforge only generically ("detecting their language") with no ecosystem list, so neither became inaccurate and neither was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry9oksjwNDqqhwBwhjyCth
