### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ Always reference these instructions first and fallback to search or bash command
 ## Working Effectively
 
 ### Prerequisites
-- **Go 1.26+**: Required for building. Check with `go version`.
+- **Go 1.27+**: Required for building. Check with `go version`.
 
 ### Bootstrap and Build
 - `make build` -- builds the `dev` binary in `bin/` directory. Takes ~1 second. NEVER CANCEL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed the Go module dependencies to their latest versions
 - changed the Go version to `1.27.0` and updated all module dependencies
 - changed struct literals and `errors.As` calls to the Go 1.27 forms required by the `modernize` linter
+- refreshed `.github/copilot-instructions.md` to require Go 1.27+ matching `go.mod`
 
 ## [0.9.7] - 2026-08-17
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.