### PR TITLE
chore(chlog): converted the changelog to chlog fragments

### DIFF
--- a/.changes/unreleased/1787693750448879078-9683.yaml
+++ b/.changes/unreleased/1787693750448879078-9683.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'changed the changelog to [chlog](https://github.com/luizjhonata/chlog) fragments: a change now writes its own YAML file under `.changes/unreleased/` through `chlog new --kind <Kind> --body "..."`, and `CHANGELOG.md` is GENERATED from them at release time by `chlog batch auto && chlog merge`. That is the one thing a single shared file cannot do — two branches each adding an entry no longer touch the same lines, so a rebase that used to conflict on `CHANGELOG.md` now conflicts on nothing. The `[Unreleased]` section was empty, so nothing had to be carried across. AutoBump already reads the fragments directly, so the release flow is unchanged.'
+time: '2026-08-25T21:35:50.448514921Z'

--- a/.changes/unreleased/1787697443601331683-1d7e.yaml
+++ b/.changes/unreleased/1787697443601331683-1d7e.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the documented minimum Go toolchain in `CONTRIBUTING.md`, which still said 1.26+ while `go.mod` requires `go 1.27.0`'
+time: '2026-08-25T22:37:23.601276753Z'

--- a/.changes/unreleased/1787697443607790337-7d21.yaml
+++ b/.changes/unreleased/1787697443607790337-7d21.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'removed the stale "update the version in `src/main.go`" item from the bump pull request checklist: there is no `src/` directory, and the build version is injected by the `Makefile` through `-X main.version=$(VERSION)` from the latest Git tag, so there is nothing to edit by hand'
+time: '2026-08-25T22:37:23.607706439Z'

--- a/.chlog.yaml
+++ b/.chlog.yaml
@@ -1,0 +1,29 @@
+# chlog — fragment-based changelog management (https://github.com/luizjhonata/chlog).
+#
+# Every value below is chlog's own default, spelled out on purpose: the file is the
+# one place a reader can see what the kinds are and which bump each one infers,
+# without going and reading the tool. Keep it in step with the `--kind` values the
+# AI-assistant block in CLAUDE.md advertises.
+#
+# No kind maps to `major`. Under SemVer a major bump means a backward-incompatible
+# change, which is a property of the change and not of its category, so it is
+# signalled per fragment by `chlog new --breaking` and never inferred from a label.
+changesDir: .changes
+unreleasedDir: unreleased
+changelogPath: CHANGELOG.md
+versionFormat: '## [{{.Version}}] - {{.Time.Format "2006-01-02"}}'
+kindFormat: '### {{.Kind}}'
+changeFormat: '- {{.Body}}'
+kinds:
+  - label: Added
+    auto: minor
+  - label: Changed
+    auto: minor
+  - label: Deprecated
+    auto: minor
+  - label: Removed
+    auto: minor
+  - label: Fixed
+    auto: patch
+  - label: Security
+    auto: patch

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,3 +109,28 @@ go vet ./...
 # Test SAST suite
 ./bin/dev project sast .
 ```
+
+<!-- chlog:start -->
+## Changelog (chlog) — MANDATORY
+
+If the repository you are working in uses chlog (a `.chlog.yaml` or `.chlog.yml`
+config file, or a `.changes/` directory, exists at the project root), the
+following is binding and ALWAYS applies: whenever you make ANY change, you MUST
+create a changelog fragment as part of the same change — automatically, without
+being asked, before committing.
+
+- Do NOT edit CHANGELOG.md directly; it is generated from fragments.
+- Create the fragment with:
+  `chlog new --kind <Kind> --body "<imperative description>"`
+- Valid kinds: Added, Changed, Deprecated, Removed, Fixed, Security
+- Choose the kind that best matches the change (e.g., new feature → Added,
+  bug fix → Fixed, behavior change → Changed, removal → Removed, security fix → Security).
+- If the change is backward-INCOMPATIBLE with the public API (a breaking
+  change), you MUST add the `--breaking` flag:
+  `chlog new --kind <Kind> --breaking --body "<description>"`.
+  This is the ONLY thing that triggers a major version bump — the kind alone
+  never does (per SemVer, major = incompatible change). When unsure whether a
+  change breaks compatibility, ask the user instead of guessing.
+- Fragments are YAML files in `.changes/unreleased/`; stage them with your commit.
+- `chlog check` fails the build when a fragment is missing — never skip it.
+<!-- chlog:end -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## :vertical_traffic_light: Quality checklist
 
-- [ ] Did you add the changes in the `CHANGELOG.md`?
+- [ ] Did you add a changelog fragment? (`chlog new --kind <Kind> --body "..."` — `CHANGELOG.md` is generated from them, never edited by hand)
 - [ ] Did you run all the code checks? (`go test`)
 - [ ] Are the tests passing?

--- a/.github/pull_request_template/bump.md
+++ b/.github/pull_request_template/bump.md
@@ -1,4 +1,4 @@
 ## :vertical_traffic_light: Quality checklist
 
-- [ ] Did you update the unreleased section on `CHANGELOG.md` with a version number and date?
+- [ ] Did you compile the pending fragments into a version section on `CHANGELOG.md`? (`chlog batch auto && chlog merge`)
 - [ ] Did you update the version of the application in `src/main.go`?

--- a/.github/pull_request_template/bump.md
+++ b/.github/pull_request_template/bump.md
@@ -1,4 +1,3 @@
 ## :vertical_traffic_light: Quality checklist
 
 - [ ] Did you compile the pending fragments into a version section on `CHANGELOG.md`? (`chlog batch auto && chlog merge`)
-- [ ] Did you update the version of the application in `src/main.go`?

--- a/.github/pull_request_template/default.md
+++ b/.github/pull_request_template/default.md
@@ -1,5 +1,5 @@
 ## :vertical_traffic_light: Quality checklist
 
-- [ ] Did you add the changes in the `CHANGELOG.md`?
+- [ ] Did you add a changelog fragment? (`chlog new --kind <Kind> --body "..."` — `CHANGELOG.md` is generated from them, never edited by hand)
 - [ ] Did you run all the code checks? (`go test`)
 - [ ] Are the tests passing?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This file is not edited by hand. Every change writes its own fragment under
+`.changes/unreleased/` with [chlog](https://github.com/luizjhonata/chlog), and a release compiles
+the pending fragments into a version section here — so two branches each adding an entry no
+longer touch the same lines, and a rebase that used to conflict on this file now conflicts on
+nothing.
+
 When a new release is proposed:
 
 1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
-2. The Unreleased section on `CHANGELOG.md` gets a version number and date;
+2. The fragments pending under `.changes/unreleased/` are compiled into a version section by `chlog batch auto && chlog merge` (AutoBump does this for you — it reads the fragments directly);
 3. Open a Pull Request with the bump version changes targeting the `main` branch;
 4. When the Pull Request is merged, a new Git tag must be created using [GitHub environment](https://github.com/rios0rios0/versainit/tags).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,28 @@ internal/
 - **go-github** -- GitHub API client (used by `ForkResolver` to get fork parent info)
 - **langforge** -- Language detection, version management, and runtime information (Go, Dart, Node, Python, Java, C#, Ruby, Terraform)
 - **cliforge** -- Self-update mechanism and automatic version check on startup
+
+<!-- chlog:start -->
+## Changelog (chlog) — MANDATORY
+
+If the repository you are working in uses chlog (a `.chlog.yaml` or `.chlog.yml`
+config file, or a `.changes/` directory, exists at the project root), the
+following is binding and ALWAYS applies: whenever you make ANY change, you MUST
+create a changelog fragment as part of the same change — automatically, without
+being asked, before committing.
+
+- Do NOT edit CHANGELOG.md directly; it is generated from fragments.
+- Create the fragment with:
+  `chlog new --kind <Kind> --body "<imperative description>"`
+- Valid kinds: Added, Changed, Deprecated, Removed, Fixed, Security
+- Choose the kind that best matches the change (e.g., new feature → Added,
+  bug fix → Fixed, behavior change → Changed, removal → Removed, security fix → Security).
+- If the change is backward-INCOMPATIBLE with the public API (a breaking
+  change), you MUST add the `--breaking` flag:
+  `chlog new --kind <Kind> --breaking --body "<description>"`.
+  This is the ONLY thing that triggers a major version bump — the kind alone
+  never does (per SemVer, major = incompatible change). When unsure whether a
+  change breaks compatibility, ask the user instead of guessing.
+- Fragments are YAML files in `.changes/unreleased/`; stage them with your commit.
+- `chlog check` fails the build when a fragment is missing — never skip it.
+<!-- chlog:end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ development practices, refer to the **[Development Guide](https://github.com/rio
 
 ## Prerequisites
 
-- [Go](https://go.dev/dl/) 1.26+
+- [Go](https://go.dev/dl/) 1.27+
 - [Make](https://www.gnu.org/software/make/)
 - [chlog](https://github.com/luizjhonata/chlog) (`go install github.com/luizjhonata/chlog@latest`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ development practices, refer to the **[Development Guide](https://github.com/rio
 
 - [Go](https://go.dev/dl/) 1.26+
 - [Make](https://www.gnu.org/software/make/)
+- [chlog](https://github.com/luizjhonata/chlog) (`go install github.com/luizjhonata/chlog@latest`)
 
 ## Development Workflow
 
@@ -29,6 +30,9 @@ development practices, refer to the **[Development Guide](https://github.com/rio
    make test
    make sast
    ```
-7. Update `CHANGELOG.md` under `[Unreleased]`
+7. Add a changelog fragment — never edit `CHANGELOG.md`, which is generated from them:
+   ```bash
+   chlog new --kind Added --body "added the thing that was not there before"
+   ```
 8. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
 9. Open a pull request against `main`


### PR DESCRIPTION
Converts this repository's changelog to [chlog](https://github.com/luizjhonata/chlog) fragments.

## What this is

`CHANGELOG.md` stops being a file anyone edits. Every change now writes its **own** YAML fragment
under `.changes/unreleased/`, and a release compiles them:

```bash
chlog new --kind Added --body "added the thing that was not there before"
chlog new --kind Changed --breaking --body "..."   # the only thing that bumps the major
chlog batch auto && chlog merge                    # at release time
```

`chlog` is [luizjhonata/chlog](https://github.com/luizjhonata/chlog) — a single Go binary,
`go install github.com/luizjhonata/chlog@latest`. This branch was produced with **v0.4.0**, and the
fragments were written by the binary itself rather than by hand, so their format is exactly what the
tool emits.

The point is the one thing a single shared file cannot do: two branches each adding an entry no
longer touch the same lines, so a rebase that used to conflict on `CHANGELOG.md` now conflicts on
nothing.

## How the existing changelog was migrated

The `[Unreleased]` section was empty when this branch was cut, so nothing had to be
carried across — the only fragment here is the one describing this change.

## Reviewing this

| File | What changed |
|---|---|
| `.chlog.yaml` | New. chlog's own defaults, spelled out so the kinds and their bump levels are readable without going to the tool |
| `.changes/unreleased/` | New. Where the pending fragments live; this branch's own is the first one in it |
| `CHANGELOG.md` | The header now says the file is not edited by hand, and the release recipe points at the fragments |
| `CONTRIBUTING.md` | Step 7 asks for `chlog new` instead of an edit to `CHANGELOG.md`, and chlog joins the prerequisites |
| `.github/pull_request_template.md`, `.github/pull_request_template/default.md` | The checklist asks for a fragment instead of a changelog edit |
| `.github/pull_request_template/bump.md` | The release checklist asks for the version section compiled by `chlog batch auto && chlog merge` |
| `CLAUDE.md` | Carries chlog's assistant block, injected with `chlog ai setup` and marked `<!-- chlog:start -->`, so re-running the command updates it in place |
| `.github/copilot-instructions.md` | Same |

## Two things called out deliberately

**No CI job was added — none is needed.** The shared `rios0rios0/pipelines` basic-checks gate this
repository already consumes at `@main` is chlog-aware: when `.chlog.yaml` is present it requires a
**new fragment** on an ordinary branch, and flips to requiring an updated `CHANGELOG.md` on a
`bump/*` branch. So this branch is gated the moment it merges, by the check that is already running.
`chlog hook install --local` runs the same check on every commit in a local clone.

**AutoBump needs no change either.** It detects the layout (`internal/domain/commands/chlog.go`) and
turns the pending fragments back into `[Unreleased]` lines before calculating the next version, so
the release flow is exactly what it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
